### PR TITLE
chore: add release workflow and docs for versioned docker images

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,76 @@
+name: Release Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.2.0)'
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and Push GHCR Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW_VERSION="${{ github.event.inputs.version }}"
+          else
+            RAW_VERSION="${GITHUB_REF_NAME}"
+          fi
+
+          VERSION="${RAW_VERSION#v}"
+          echo "raw=${RAW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/garbanzo
+          tags: |
+            type=raw,value=${{ steps.version.outputs.raw }}
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ !contains(steps.version.outputs.raw, '-') }}
+          labels: |
+            org.opencontainers.image.title=Garbanzo
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,8 @@ garbanzo-bot/
 │   ├── ROADMAP.md            # Phased implementation plan
 │   ├── ARCHITECTURE.md       # Data flow, routing, multimedia pipeline docs
 │   ├── INFRASTRUCTURE.md     # Hardware/network reference
-│   └── SETUP_EXAMPLES.md     # Reusable setup command recipes
+│   ├── SETUP_EXAMPLES.md     # Reusable setup command recipes
+│   └── RELEASES.md           # Versioning and Docker release workflow
 ├── data/                     # Runtime data (gitignored DBs, persisted state)
 ├── scripts/
 │   ├── setup.mjs             # Interactive setup wizard

--- a/README.md
+++ b/README.md
@@ -360,6 +360,13 @@ docker compose logs -f garbanzo
 curl http://127.0.0.1:3001/health
 ```
 
+To deploy a specific release image:
+
+```bash
+APP_VERSION=0.1.1 docker compose pull garbanzo
+APP_VERSION=0.1.1 docker compose up -d
+```
+
 Alternative: systemd user service for native Node deployment (`scripts/garbanzo.service`).
 
 If you previously used `garbanzo-bot.service`, migrate to `garbanzo.service`.
@@ -367,6 +374,8 @@ If you previously used `garbanzo-bot.service`, migrate to `garbanzo.service`.
 The health endpoint returns JSON with connection status, uptime, memory usage, message staleness, and backup integrity status.
 
 ## Support Garbanzo
+
+[![GitHub Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-Support-pink?logo=githubsponsors)](https://github.com/sponsors/jjhickman)
 
 If Garbanzo is useful for your community, you can support development and operating costs.
 
@@ -401,6 +410,7 @@ Repo guardrails are configured under `.github/`:
 - `pull_request_template.md` enforces verification checklist discipline
 - `dependabot.yml` keeps npm/docker dependencies updated weekly
 - `credential-rotation-reminder.yml` opens a monthly credential rotation checklist issue
+- `release-docker.yml` builds and publishes versioned Docker images to GHCR on `v*` tags
 - `FUNDING.yml` enables sponsorship links in GitHub UI
 
 ## GitHub Account Workflow
@@ -442,6 +452,7 @@ Use `bash scripts/rotate-gh-secrets.sh --help` for full options.
 - [INFRASTRUCTURE.md](docs/INFRASTRUCTURE.md) — Hardware and network reference
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — Message flow, AI routing, and multimedia pipeline
 - [SETUP_EXAMPLES.md](docs/SETUP_EXAMPLES.md) — Interactive and non-interactive setup recipes
+- [RELEASES.md](docs/RELEASES.md) — Versioning, tag flow, and Docker image release process
 - [CHANGELOG.md](CHANGELOG.md) — Full release history
 - [CONTRIBUTING.md](CONTRIBUTING.md) — How to contribute
 - [AGENTS.md](AGENTS.md) — Coding agent instructions and conventions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@
 
 services:
   garbanzo:
+    image: ghcr.io/jjhickman/garbanzo:${APP_VERSION:-dev}
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,4 +156,5 @@ Operational protections:
 
 - Default deployment: Docker Compose
 - Alternative deployment: systemd user service on Terra (native Node)
+- Release images are published to GHCR via tag-driven workflow (`v*`)
 - Do not run multiple bot instances against same Baileys auth state

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,54 @@
+# Releases
+
+This project uses semantic versioning and tag-driven Docker image releases.
+
+## Release Flow
+
+1. Ensure `main` is green:
+
+```bash
+npm run check
+npm run gh:dependabot
+```
+
+2. Bump version in `package.json` and create git tag:
+
+```bash
+# patch/minor/major as needed
+npm version patch
+```
+
+This creates a commit and tag like `v0.1.1`.
+
+3. Push commit + tag:
+
+```bash
+git push origin main --follow-tags
+```
+
+4. GitHub Action `release-docker.yml` builds and pushes:
+
+- `ghcr.io/jjhickman/garbanzo:vX.Y.Z`
+- `ghcr.io/jjhickman/garbanzo:X.Y.Z`
+- `ghcr.io/jjhickman/garbanzo:latest` (only for non-prerelease tags)
+
+## Version Injection Behavior
+
+- Docker build uses `APP_VERSION` build arg.
+- Runtime exposes `GARBANZO_VERSION` env var.
+- `!release` message header auto-includes version from:
+  1. `GARBANZO_VERSION`, else
+  2. `package.json` version.
+
+## Deploying a Released Image
+
+Set `APP_VERSION` in your `.env` before deploy, then pull and restart:
+
+```bash
+APP_VERSION=0.1.1 docker compose pull garbanzo
+APP_VERSION=0.1.1 docker compose up -d
+```
+
+## Manual Workflow Dispatch
+
+You can run `Release Docker Image` manually from Actions with an explicit version input (e.g., `v0.2.0`).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -267,6 +267,7 @@ Research and adopt established, free, trustworthy tools for automated security. 
 5. [x] **Automated backups verification** — health check now reports latest nightly backup integrity (`verifyLatestBackupIntegrity` + SQLite `PRAGMA integrity_check`).
 6. [x] **Rate limiting on health endpoint** — basic per-IP rate limiting added to `/health`.
 7. [x] **Credential rotation workflow** — monthly GitHub Action reminder (`credential-rotation-reminder.yml`) + local helper for rotating Actions secrets from env (`npm run rotate:gh-secrets`).
+8. [x] **Release automation + version metadata** — tag-driven GHCR image publishing (`release-docker.yml`) and version injection into release notes / Docker runtime (`APP_VERSION`, `GARBANZO_VERSION`).
 7. [ ] **Log monitoring/alerting** — evaluate lightweight solutions (e.g., Logwatch, simple Pino log grep script) to surface error spikes or unusual patterns without a full observability stack.
 
 ### Gate

--- a/docs/SETUP_EXAMPLES.md
+++ b/docs/SETUP_EXAMPLES.md
@@ -72,3 +72,10 @@ docker compose up -d
 docker compose logs -f garbanzo
 curl http://127.0.0.1:3001/health
 ```
+
+Deploy a specific release image tag:
+
+```bash
+APP_VERSION=0.1.1 docker compose pull garbanzo
+APP_VERSION=0.1.1 docker compose up -d
+```


### PR DESCRIPTION
## Objective
Standardize release operations with tag-driven Docker image publishing and clear version/deploy documentation.

## Problem
Release/version behavior was partially implemented in code but lacked a complete documented workflow and automated Docker publishing on tags.

## Solution
- Add `.github/workflows/release-docker.yml` to build/push GHCR images on `v*` tags (and manual dispatch)
- Add `docs/RELEASES.md` with version bump, tagging, push, and deploy steps
- Update compose/docs to use versioned image references and release deploy examples
- Link release process docs from README and AGENTS references

## Verification
- [x] `npm run check`

## Risk and Rollback
- Risk level: low
- Rollback: revert workflow/doc changes if release flow needs redesign.