### PR TITLE
feat: add kuma-friendly health config and release rerun controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,11 @@ GITHUB_ISSUES_REPO=jjhickman/garbanzo-bot
 # Ollama endpoint (local inference on Terra)
 OLLAMA_BASE_URL=http://127.0.0.1:11434
 
+# Health endpoint (for local probes / Uptime Kuma)
+HEALTH_PORT=3001
+# Default localhost only; set to 0.0.0.0 when monitoring from another host.
+HEALTH_BIND_HOST=127.0.0.1
+
 # Log level: debug | info | warn | error
 LOG_LEVEL=info
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -9,6 +9,9 @@ on:
       version:
         description: 'Release version (e.g. v0.2.0)'
         required: true
+      git_ref:
+        description: 'Git ref to build (tag/branch/SHA). Default: current ref'
+        required: false
 
 permissions:
   contents: read
@@ -26,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.git_ref || github.ref }}
 
       - name: Resolve version
         id: version
@@ -100,6 +105,7 @@ jobs:
           docker run -d --name garbanzo-smoke \
             -p 127.0.0.1:39001:3001 \
             -e HEALTH_ONLY=true \
+            -e HEALTH_BIND_HOST=0.0.0.0 \
             -e MESSAGING_PLATFORM=whatsapp \
             -e OWNER_JID=test_owner@s.whatsapp.net \
             -e OPENROUTER_API_KEY=test_key_ci \

--- a/README.md
+++ b/README.md
@@ -392,6 +392,23 @@ If you previously used `garbanzo-bot.service`, migrate to `garbanzo.service`.
 
 The health endpoint returns JSON with connection status, uptime, memory usage, message staleness, and backup integrity status.
 
+### Monitoring with Uptime Kuma
+
+If your Kuma dashboard is running on another host (for example `nas.local`), expose health on a reachable bind host:
+
+```bash
+HEALTH_BIND_HOST=0.0.0.0
+HEALTH_PORT=3001
+```
+
+Then configure an HTTP monitor in Kuma to check:
+
+```text
+http://<garbanzo-host>:3001/health
+```
+
+Keep network access restricted to trusted LAN/VPN segments.
+
 ## Support Garbanzo
 
 [![GitHub Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-Support-pink?logo=githubsponsors)](https://github.com/sponsors/jjhickman)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - NODE_ENV=production
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - GARBANZO_VERSION=${APP_VERSION:-dev}
+      - HEALTH_PORT=${HEALTH_PORT:-3001}
+      - HEALTH_BIND_HOST=0.0.0.0
 
     # Health check port (internal only by default)
     ports:

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -16,7 +16,7 @@
 
 | Service | Port | Binding | Notes |
 |---------|------|---------|-------|
-| **Garbanzo** | 3001 | localhost | Health check endpoint (`/health`) — JSON: connection status, uptime, memory, staleness, reconnect count, backup integrity status; includes basic per-IP rate limiting |
+| **Garbanzo** | 3001 (configurable) | `127.0.0.1` default, configurable via `HEALTH_BIND_HOST` | Health check endpoint (`/health`) — JSON: connection status, uptime, memory, staleness, reconnect count, backup integrity status; includes basic per-IP rate limiting |
 | Ollama | 11434 | localhost | 98.8 tok/s, qwen3:8b default |
 | ChromaDB | 8000 | localhost | RAG embeddings |
 | Whisper STT | 8090 | localhost | Speech-to-text (Docker) |

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -83,6 +83,7 @@ APP_VERSION=0.1.1 docker compose up -d
 You can run workflows manually from Actions:
 
 - `Release Docker Image` with explicit version input (e.g., `v0.2.0`)
+  - optional `git_ref` input to build an existing tag/commit
 - `Release Native Binaries` with optional `git_ref` input (tag/branch/SHA)
 
 This is useful for rerunning release asset generation without creating a new tag.

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -348,6 +348,12 @@ async function main() {
     const appVersion = nonInteractive
       ? (cli.options['app-version'] ?? existing.APP_VERSION ?? DEFAULT_APP_VERSION)
       : await rl.question(`APP_VERSION [${existing.APP_VERSION ?? DEFAULT_APP_VERSION}]: `);
+    const healthPort = nonInteractive
+      ? (cli.options['health-port'] ?? existing.HEALTH_PORT ?? '3001')
+      : await rl.question(`HEALTH_PORT [${existing.HEALTH_PORT ?? '3001'}]: `);
+    const healthBindHost = nonInteractive
+      ? (cli.options['health-bind-host'] ?? existing.HEALTH_BIND_HOST ?? '127.0.0.1')
+      : await rl.question(`HEALTH_BIND_HOST [${existing.HEALTH_BIND_HOST ?? '127.0.0.1'}]: `);
 
     const githubSponsorsUrl = nonInteractive
       ? (cli.options['github-sponsors-url'] ?? existing.GITHUB_SPONSORS_URL ?? '')
@@ -466,6 +472,8 @@ async function main() {
       OLLAMA_BASE_URL: (ollamaBaseUrl || existing.OLLAMA_BASE_URL || 'http://127.0.0.1:11434').trim(),
       LOG_LEVEL: (existing.LOG_LEVEL || 'info').trim(),
       APP_VERSION: (appVersion || existing.APP_VERSION || DEFAULT_APP_VERSION).trim(),
+      HEALTH_PORT: (healthPort || existing.HEALTH_PORT || '3001').trim(),
+      HEALTH_BIND_HOST: (healthBindHost || existing.HEALTH_BIND_HOST || '127.0.0.1').trim(),
       OWNER_JID: (ownerJid || existing.OWNER_JID || 'your_number@s.whatsapp.net').trim(),
     };
 
@@ -505,6 +513,8 @@ async function main() {
       `OLLAMA_BASE_URL=${finalEnv.OLLAMA_BASE_URL}`,
       `LOG_LEVEL=${finalEnv.LOG_LEVEL}`,
       `APP_VERSION=${finalEnv.APP_VERSION}`,
+      `HEALTH_PORT=${finalEnv.HEALTH_PORT}`,
+      `HEALTH_BIND_HOST=${finalEnv.HEALTH_BIND_HOST}`,
       '',
     ].join('\n');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,12 +31,14 @@ async function main(): Promise<void> {
     cloudProviders,
     messagingPlatform: config.MESSAGING_PLATFORM,
     healthOnlyMode,
+    healthPort: config.HEALTH_PORT,
+    healthBindHost: config.HEALTH_BIND_HOST,
     ollamaUrl: config.OLLAMA_BASE_URL,
     logLevel: config.LOG_LEVEL,
   }, 'Configuration loaded');
 
   // Start health check server + memory watchdog for monitoring
-  startHealthServer();
+  startHealthServer(config.HEALTH_PORT, config.HEALTH_BIND_HOST);
   startMemoryWatchdog();
 
   // Start Ollama warm-up pings to prevent model unloading

--- a/src/middleware/health.ts
+++ b/src/middleware/health.ts
@@ -110,7 +110,7 @@ function getCachedBackupStatus(now: number): { checkedAt: number; status: Backup
 /**
  * Start the local HTTP health endpoint (`/health`) with lightweight abuse protection.
  */
-export function startHealthServer(port: number = 3001): void {
+export function startHealthServer(port: number = 3001, host: string = '127.0.0.1'): void {
   server = createServer((req, res) => {
     if (req.url === '/health' && req.method === 'GET') {
       const now = Date.now();
@@ -151,8 +151,8 @@ export function startHealthServer(port: number = 3001): void {
     }
   });
 
-  server.listen(port, '127.0.0.1', () => {
-    logger.info({ port, url: `http://127.0.0.1:${port}/health` }, 'Health check server started');
+  server.listen(port, host, () => {
+    logger.info({ port, host, url: `http://${host}:${port}/health` }, 'Health check server started');
   });
 
   server.on('error', (err) => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -49,6 +49,8 @@ const envSchema = z.object({
   GITHUB_ISSUES_REPO: z.string().default('jjhickman/garbanzo-bot'),
 
   // Infrastructure
+  HEALTH_PORT: z.coerce.number().int().min(1).max(65535).default(3001),
+  HEALTH_BIND_HOST: z.string().min(1).default('127.0.0.1'),
   LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
   OWNER_JID: z.string().min(1, 'OWNER_JID is required — set in .env'),
 });


### PR DESCRIPTION
## Objective
Support external health monitoring (e.g., Uptime Kuma on `nas.local`) and make release workflows easier to rerun safely.

## Problem
- Health endpoint was fixed to localhost and not configurable for external monitors.
- Release Docker workflow dispatch lacked a git ref selector.
- Smoke test container health binding assumptions caused false negatives.

## Solution
- Add config/env for health endpoint binding:
  - `HEALTH_PORT`
  - `HEALTH_BIND_HOST`
- Update health server startup to use configurable host/port and log effective URL.
- Update setup wizard to capture/write health bind settings.
- Update compose runtime for monitor-friendly bind (`HEALTH_BIND_HOST=0.0.0.0`).
- Add `git_ref` input to `release-docker.yml` workflow_dispatch.
- Pass `HEALTH_BIND_HOST=0.0.0.0` in release smoke test container.
- Update docs for Kuma monitor setup and release rerun behavior.

## Verification
- [x] `npm run check`

## Risk and Rollback
- Risk: low
- Rollback: revert this PR to restore localhost-only health bind behavior.