### PR TITLE
fix: support release-tag targeting for manual native reruns

### DIFF
--- a/.github/workflows/release-native-binaries.yml
+++ b/.github/workflows/release-native-binaries.yml
@@ -9,6 +9,9 @@ on:
       git_ref:
         description: 'Git ref to build (tag like v0.1.1, branch, or SHA). Default: current ref'
         required: false
+      release_tag:
+        description: 'Release tag to publish assets to (e.g., v0.1.1). Required for manual reruns from branches.'
+        required: false
 
 permissions:
   contents: write
@@ -104,6 +107,24 @@ jobs:
     needs: build-binaries
 
     steps:
+      - name: Resolve release tag
+        id: release_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.release_tag }}"
+            if [ -z "$TAG" ]; then
+              echo "release_tag is required when manually dispatching this workflow."
+              exit 1
+            fi
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+
+          echo "value=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
@@ -112,6 +133,7 @@ jobs:
       - name: Publish assets to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.release_tag.outputs.value }}
           files: |
             release-artifacts/**/*.tar.gz
             release-artifacts/**/*.zip

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -84,6 +84,8 @@ You can run workflows manually from Actions:
 
 - `Release Docker Image` with explicit version input (e.g., `v0.2.0`)
   - optional `git_ref` input to build an existing tag/commit
-- `Release Native Binaries` with optional `git_ref` input (tag/branch/SHA)
+- `Release Native Binaries` with:
+  - optional `git_ref` input (tag/branch/SHA) for build source
+  - `release_tag` input (required for manual dispatch) to select which GitHub Release receives assets
 
 This is useful for rerunning release asset generation without creating a new tag.


### PR DESCRIPTION
## Objective
Allow manually dispatched native release reruns to attach artifacts to a specific GitHub Release tag.

## Problem
Manual runs from `main` had no tag context, so the publish step failed with:
`GitHub Releases requires a tag`.

## Solution
- Add `release_tag` workflow_dispatch input to `Release Native Binaries`.
- Resolve the effective tag in a dedicated step.
- Fail fast for manual dispatches that omit `release_tag`.
- Pass resolved `tag_name` to `softprops/action-gh-release`.
- Update release docs for the new manual dispatch contract.

## Verification
- [x] `npm run check`

## Notes
This keeps reruns flexible (`git_ref` for build source) while explicitly controlling where assets are published (`release_tag`).