### PR TITLE
feat: add kuma monitor guidance and optional docker hub release publishing

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -32,6 +32,21 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git_ref || github.ref }}
 
+      - name: Resolve registry targets
+        id: registries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "ghcr_image=ghcr.io/${{ github.repository_owner }}/garbanzo" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${{ vars.DOCKERHUB_IMAGE }}" ] && [ -n "${{ vars.DOCKERHUB_USERNAME }}" ] && [ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+            echo "dockerhub_enabled=true" >> "$GITHUB_OUTPUT"
+            echo "dockerhub_image=${{ vars.DOCKERHUB_IMAGE }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "dockerhub_enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve version
         id: version
         run: |
@@ -58,11 +73,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate Docker metadata
-        id: meta
+      - name: Log in to Docker Hub
+        if: ${{ steps.registries.outputs.dockerhub_enabled == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate GHCR metadata
+        id: meta_ghcr
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/garbanzo
+          images: ${{ steps.registries.outputs.ghcr_image }}
           tags: |
             type=raw,value=${{ steps.version.outputs.raw }}
             type=raw,value=${{ steps.version.outputs.version }}
@@ -72,7 +95,22 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
 
-      - name: Build and push
+      - name: Generate Docker Hub metadata
+        if: ${{ steps.registries.outputs.dockerhub_enabled == 'true' }}
+        id: meta_dockerhub
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.registries.outputs.dockerhub_image }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.raw }}
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ !contains(steps.version.outputs.raw, '-') }}
+          labels: |
+            org.opencontainers.image.title=Garbanzo
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and push GHCR image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -80,8 +118,20 @@ jobs:
           push: true
           build-args: |
             APP_VERSION=${{ steps.version.outputs.version }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_ghcr.outputs.tags }}
+          labels: ${{ steps.meta_ghcr.outputs.labels }}
+
+      - name: Build and push Docker Hub image
+        if: ${{ steps.registries.outputs.dockerhub_enabled == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
+          tags: ${{ steps.meta_dockerhub.outputs.tags }}
+          labels: ${{ steps.meta_dockerhub.outputs.labels }}
 
   smoke-test:
     name: Smoke Test Published Image

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Copy `.env.example` to `.env` and configure:
 | `GITHUB_ISSUES_TOKEN` | No | Token used to create GitHub issues from owner-approved feedback |
 | `GITHUB_ISSUES_REPO` | No | Target repo for issue creation (`owner/repo`) |
 | `OLLAMA_BASE_URL` | No | Local model inference (default: `http://127.0.0.1:11434`) |
+| `HEALTH_PORT` | No | Health endpoint port (default: `3001`) |
+| `HEALTH_BIND_HOST` | No | Health bind host (`127.0.0.1` default, use `0.0.0.0` for external monitors) |
 | `APP_VERSION` | No | Version marker used for Docker image labels + release note headers |
 | `OWNER_JID` | Yes | Owner WhatsApp JID for admin features |
 | `LOG_LEVEL` | No | `debug`, `info`, `warn`, `error` (default: `info`) |
@@ -407,6 +409,23 @@ Then configure an HTTP monitor in Kuma to check:
 http://<garbanzo-host>:3001/health
 ```
 
+Recommended Kuma monitor settings:
+
+- **Monitor type:** HTTP(s)
+- **Method:** GET
+- **Heartbeat interval:** 30s
+- **Request timeout:** 5s
+- **Retries:** 3
+- **Accepted status codes:** 200-299
+- **Resend interval:** 30m (or your preferred alert noise level)
+
+Suggested setup on `nas.local`:
+
+1. Add monitor name `garbanzo-health` with URL `http://<garbanzo-host>:3001/health`.
+2. Save, then verify response body includes `status`, `stale`, `uptime`, and `backup` keys.
+3. Add your notification channel (Discord, email, Slack, etc.) and run a test notification.
+4. Optional second monitor: keyword check on `"stale":false` if you want alerting on stale chat activity, not just process uptime.
+
 Keep network access restricted to trusted LAN/VPN segments.
 
 ## Support Garbanzo
@@ -446,7 +465,7 @@ Repo guardrails are configured under `.github/`:
 - `pull_request_template.md` enforces verification checklist discipline
 - `dependabot.yml` keeps npm/docker dependencies updated weekly
 - `credential-rotation-reminder.yml` opens a monthly credential rotation checklist issue
-- `release-docker.yml` builds and publishes versioned Docker images to GHCR on `v*` tags
+- `release-docker.yml` builds and publishes versioned Docker images to GHCR (and optional Docker Hub) on `v*` tags
 - `release-native-binaries.yml` builds and attaches cross-platform native bundles on `v*` tags
 - release Docker workflow runs a smoke test against published image health endpoint
 - `FUNDING.yml` enables sponsorship links in GitHub UI

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -40,6 +40,10 @@ git push origin main --follow-tags
 - `ghcr.io/jjhickman/garbanzo:vX.Y.Z`
 - `ghcr.io/jjhickman/garbanzo:X.Y.Z`
 - `ghcr.io/jjhickman/garbanzo:latest` (only for non-prerelease tags)
+- optional Docker Hub images (when configured):
+  - `<dockerhub-image>:vX.Y.Z`
+  - `<dockerhub-image>:X.Y.Z`
+  - `<dockerhub-image>:latest` (only for non-prerelease tags)
 - native bundles attached to release:
   - `garbanzo-linux-x64.tar.gz`
   - `garbanzo-macos.tar.gz`
@@ -89,3 +93,15 @@ You can run workflows manually from Actions:
   - `release_tag` input (required for manual dispatch) to select which GitHub Release receives assets
 
 This is useful for rerunning release asset generation without creating a new tag.
+
+## Optional Docker Hub Publishing
+
+`Release Docker Image` can push to Docker Hub in addition to GHCR.
+
+Set these repo settings in GitHub (`Settings` -> `Secrets and variables` -> `Actions`):
+
+- Variable `DOCKERHUB_IMAGE` (example: `yourdockerhubuser/garbanzo`)
+- Variable `DOCKERHUB_USERNAME`
+- Secret `DOCKERHUB_TOKEN` (Docker Hub access token)
+
+If any of these are missing, Docker Hub publish is skipped and GHCR publish still runs.


### PR DESCRIPTION
## Objective
Improve release operations with concrete Kuma monitor guidance and optional Docker Hub image publishing.

## What changed
- Added practical Uptime Kuma monitor defaults + `nas.local` setup checklist in README.
- Documented `HEALTH_BIND_HOST` and `HEALTH_PORT` env vars in README.
- Extended release docs with optional Docker Hub publishing setup and behavior.
- Updated `release-docker.yml` to:
  - always publish to GHCR
  - publish to Docker Hub when `DOCKERHUB_IMAGE`, `DOCKERHUB_USERNAME`, and `DOCKERHUB_TOKEN` are configured
  - keep smoke test behavior on GHCR image unchanged

## Why
- Kuma setup is now explicit and repeatable for LAN-based monitoring.
- Docker release workflow now supports dual-publishing without breaking existing GHCR-only setups.

## Verification
- [x] `npm run check`