### PR TITLE
chore: expose health port for kuma

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,9 @@ services:
       - HEALTH_PORT=${HEALTH_PORT:-3001}
       - HEALTH_BIND_HOST=0.0.0.0
 
-    # Health check port (internal only by default)
+    # Health check port (reachable on LAN for external monitoring)
     ports:
-      - "127.0.0.1:3001:3001"
+      - "0.0.0.0:3001:3001"
 
     # Persistent data volumes
     volumes:


### PR DESCRIPTION
## Objective
Expose the health endpoint on the LAN so a remote Uptime Kuma instance (e.g. `nas.local`) can monitor `/health`.

## Change
- Update Docker Compose port publishing from localhost-only to LAN-reachable:
  - `127.0.0.1:3001:3001` -> `0.0.0.0:3001:3001`

## Notes
- Container still binds `HEALTH_BIND_HOST=0.0.0.0` internally.
- This is for trusted LAN/VPN monitoring only.

## Verification
- Manual: `curl http://<host-ip>:3001/health` from another host on the LAN.