### PR TITLE
chore: drop macos x64 native bundle

### DIFF
--- a/.github/workflows/release-native-binaries.yml
+++ b/.github/workflows/release-native-binaries.yml
@@ -40,14 +40,6 @@ jobs:
             binary_name: garbanzo
             pkg_target: node22-macos-arm64
             archive_ext: tar.gz
-          # macOS x64 builds have become less consistent on GitHub-hosted runners.
-          # We keep this target as best-effort and do not fail the entire release if it breaks.
-          - os: macos-14
-            bundle_name: garbanzo-macos-x64
-            binary_name: garbanzo
-            pkg_target: node22-macos-x64
-            archive_ext: tar.gz
-            allow_failure: true
           - os: windows-latest
             bundle_name: garbanzo-windows-x64
             binary_name: garbanzo.exe

--- a/README.md
+++ b/README.md
@@ -402,7 +402,6 @@ Cross-platform portable binaries are published on version tags (`v*`) as release
 - `garbanzo-linux-x64.tar.gz`
 - `garbanzo-linux-arm64.tar.gz`
 - `garbanzo-macos-arm64.tar.gz`
-- `garbanzo-macos-x64.tar.gz`
 - `garbanzo-windows-x64.zip`
 
 Alternative: systemd user service for native Node deployment (`scripts/garbanzo.service`).

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -48,7 +48,6 @@ git push origin main --follow-tags
   - `garbanzo-linux-x64.tar.gz`
   - `garbanzo-linux-arm64.tar.gz`
   - `garbanzo-macos-arm64.tar.gz`
-  - `garbanzo-macos-x64.tar.gz`
   - `garbanzo-windows-x64.zip`
 
 5. Open a release checklist issue from `.github/ISSUE_TEMPLATE/release-checklist.yml` and track deploy verification.


### PR DESCRIPTION
## Problem
The macOS x64 bundle repeatedly blocks `Release Native Binaries` due to runner availability/label changes.

## Change
- Remove macOS x64 native bundle generation from `.github/workflows/release-native-binaries.yml`.
- Update docs to reflect the supported set of bundles.

## Why
This repo now targets ARM-first macOS (Apple Silicon) plus Linux/Windows. Dropping x64 keeps releases reliable and prevents a non-critical target from blocking publication.

## Resulting Release Assets
- `garbanzo-linux-x64.tar.gz`
- `garbanzo-linux-arm64.tar.gz`
- `garbanzo-macos-arm64.tar.gz`
- `garbanzo-windows-x64.zip`