### PR TITLE
chore: docs + docker hub overview sync + demo placeholders

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -135,6 +135,16 @@ jobs:
           tags: ${{ steps.meta_dockerhub.outputs.tags }}
           labels: ${{ steps.meta_dockerhub.outputs.labels }}
 
+      - name: Update Docker Hub repository overview
+        if: ${{ steps.registries.outputs.dockerhub_enabled == 'true' }}
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ steps.registries.outputs.dockerhub_image }}
+          short-description: WhatsApp community bot with AI routing and ops tooling.
+          readme-filepath: ./docs/DOCKERHUB_OVERVIEW.md
+
   smoke-test:
     name: Smoke Test Published Image
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -98,37 +98,23 @@ More recipes: [`docs/SETUP_EXAMPLES.md`](docs/SETUP_EXAMPLES.md)
 
 On first run, Baileys will display a QR code in the terminal. Scan it with WhatsApp (Settings > Linked Devices) to authenticate. Auth state persists in `baileys_auth/` across restarts.
 
-## Demo Placeholders
+## Demo
 
-Use these placeholders to drop in media for first-time users evaluating product value.
+Setup and onboarding:
 
-### Setup & Onboarding
+![Setup Wizard Demo](docs/assets/demos/setup-wizard.svg)
+![WhatsApp QR Linking](docs/assets/screenshots/qr-link.svg)
 
-- `SETUP_WIZARD_GIF` → `docs/assets/demos/setup-wizard.gif`
-- `WHATSAPP_QR_SCREENSHOT` → `docs/assets/screenshots/qr-link.png`
+Core value in action:
 
-### Core Value in Action
+![Mention to Response Flow](docs/assets/demos/mention-to-response.svg)
+![Event Enrichment Example](docs/assets/screenshots/event-enrichment.svg)
+![Catchup Summary Example](docs/assets/screenshots/summary-catchup.svg)
 
-- `MENTION_RESPONSE_GIF` → `docs/assets/demos/mention-to-response.gif`
-- `EVENT_ENRICHMENT_SCREENSHOT` → `docs/assets/screenshots/event-enrichment.png`
-- `SUMMARY_CATCHUP_SCREENSHOT` → `docs/assets/screenshots/summary-catchup.png`
+Admin and reliability:
 
-### Admin & Reliability
-
-- `OWNER_DIGEST_SCREENSHOT` → `docs/assets/screenshots/owner-digest.png`
-- `HEALTH_ENDPOINT_SCREENSHOT` → `docs/assets/screenshots/health-endpoint-json.png`
-
-Embed template:
-
-```md
-![Setup Wizard Demo](docs/assets/demos/setup-wizard.gif)
-![WhatsApp QR Linking](docs/assets/screenshots/qr-link.png)
-![Mention to Response Flow](docs/assets/demos/mention-to-response.gif)
-![Event Enrichment Example](docs/assets/screenshots/event-enrichment.png)
-![Catchup Summary Example](docs/assets/screenshots/summary-catchup.png)
-![Owner Daily Digest](docs/assets/screenshots/owner-digest.png)
-![Health Endpoint Output](docs/assets/screenshots/health-endpoint-json.png)
-```
+![Owner Daily Digest](docs/assets/screenshots/owner-digest.svg)
+![Health Endpoint Output](docs/assets/screenshots/health-endpoint-json.svg)
 
 ## Features
 
@@ -443,6 +429,23 @@ Suggested setup on `nas.local`:
 4. Optional second monitor: keyword check on `"stale":false` if you want alerting on stale chat activity, not just process uptime.
 
 Keep network access restricted to trusted LAN/VPN segments.
+
+If you expose port `3001` on your LAN for external monitoring, restrict it to your monitor host. For Docker deployments, the most reliable place is the `DOCKER-USER` iptables chain (so Docker's own rules can't bypass it):
+
+```bash
+# Allow Uptime Kuma (NAS) to reach /health
+sudo iptables -I DOCKER-USER 1 -i <lan-iface> -p tcp -s 192.168.50.219 --dport 3001 -j ACCEPT
+
+# Drop everyone else on LAN -> 3001
+sudo iptables -I DOCKER-USER 2 -i <lan-iface> -p tcp --dport 3001 -j DROP
+```
+
+To persist across reboots on Ubuntu, install and save:
+
+```bash
+sudo apt-get install -y iptables-persistent
+sudo netfilter-persistent save
+```
 
 ## Support Garbanzo
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,8 @@ services:
       - HEALTH_PORT=${HEALTH_PORT:-3001}
       - HEALTH_BIND_HOST=0.0.0.0
 
-    # Health check port (reachable on LAN for external monitoring)
+    # Health check port (reachable on LAN for external monitoring).
+    # If you publish this to your LAN, restrict it to trusted hosts (e.g., iptables `DOCKER-USER` allowlist).
     ports:
       - "0.0.0.0:3001:3001"
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,7 +131,7 @@ SQLite database (`data/garbanzo.db`, WAL mode) stores:
 
 ## Health and Operations
 
-Health endpoint (`127.0.0.1:3001/health`) reports:
+Health endpoint (default `http://127.0.0.1:3001/health`) reports:
 
 - connection state and staleness
 - uptime/reconnect count
@@ -144,6 +144,7 @@ Operational protections:
 - retry queue for transient AI failures
 - process-level `unhandledRejection` / `uncaughtException` handlers
 - basic health endpoint request rate limiting
+- if exposed beyond localhost (for Kuma), restrict access to trusted hosts (iptables `DOCKER-USER` allowlist for Docker)
 
 ## Security Boundaries
 

--- a/docs/DOCKERHUB_OVERVIEW.md
+++ b/docs/DOCKERHUB_OVERVIEW.md
@@ -1,0 +1,56 @@
+# Garbanzo Bot
+
+Garbanzo is a WhatsApp community bot (Baileys-based) that routes group mentions and commands to AI providers (configurable failover + optional local Ollama).
+
+This image is built for small-to-medium community groups that want:
+
+- Mention-driven responses (no surprise spam)
+- Operations-friendly health endpoint (`/health`)
+- Docker-first deployment with persistent auth + SQLite state
+
+## Quick Start (Docker Compose)
+
+1) Copy env template:
+
+```bash
+cp .env.example .env
+```
+
+2) Set required vars in `.env` (at minimum: `OWNER_JID` and one AI provider key).
+
+3) Run a pinned release:
+
+```bash
+APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+Health check:
+
+```bash
+curl http://127.0.0.1:3001/health
+```
+
+## Tags
+
+This repo publishes both GHCR and Docker Hub tags.
+
+- `latest`
+  - Most recent stable release
+  - Only published for non-prerelease versions
+- `0.1.1`
+  - Semver tag without the leading `v`
+- `v0.1.1`
+  - Git tag style (kept for convenience)
+
+All tags are multi-arch where available:
+
+- `linux/amd64`
+- `linux/arm64`
+
+## Notes
+
+- This container persists WhatsApp auth state and SQLite data via Docker volumes.
+- Exposing the health port on your LAN is useful for Uptime Kuma, but you should restrict access to trusted hosts (firewall or reverse proxy).
+
+Source code and docs: https://github.com/jjhickman/garbanzo-bot

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -16,7 +16,7 @@
 
 | Service | Port | Binding | Notes |
 |---------|------|---------|-------|
-| **Garbanzo** | 3001 (configurable) | `127.0.0.1` default, configurable via `HEALTH_BIND_HOST` | Health check endpoint (`/health`) — JSON: connection status, uptime, memory, staleness, reconnect count, backup integrity status; includes basic per-IP rate limiting |
+| **Garbanzo** | 3001 (configurable) | `127.0.0.1` default, configurable via `HEALTH_BIND_HOST` | Health check endpoint (`/health`) — JSON: connection status, uptime, memory, staleness, reconnect count, backup integrity status. If published on LAN for Kuma, restrict to the monitor host (iptables `DOCKER-USER` allowlist). |
 | Ollama | 11434 | localhost | 98.8 tok/s, qwen3:8b default |
 | ChromaDB | 8000 | localhost | RAG embeddings |
 | Whisper STT | 8090 | localhost | Speech-to-text (Docker) |

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -111,7 +111,9 @@ This is useful for rerunning release asset generation without creating a new tag
 Set these repo settings in GitHub (`Settings` -> `Secrets and variables` -> `Actions`):
 
 - Variable `DOCKERHUB_IMAGE` (example: `yourdockerhubuser/garbanzo`)
-- Variable `DOCKERHUB_USERNAME`
+- Variable `DOCKERHUB_USERNAME` (Docker Hub username, not email)
 - Secret `DOCKERHUB_TOKEN` (Docker Hub access token)
 
 If any of these are missing, Docker Hub publish is skipped and GHCR publish still runs.
+
+When Docker Hub publishing is enabled, the workflow also syncs the Docker Hub repository overview from `docs/DOCKERHUB_OVERVIEW.md`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -132,7 +132,7 @@
 **Goal:** Make the bot self-monitoring, resilient, and cost-aware. Keep it running without babysitting.
 
 ### High Priority (low effort, high value)
-1. ~~**Health check HTTP endpoint** (`src/middleware/health.ts`) — HTTP server on `127.0.0.1:3001/health`, returns JSON: connection status, uptime, staleness, last message age, reconnect count, memory usage~~ ✅ Live
+1. ~~**Health check HTTP endpoint** (`src/middleware/health.ts`) — HTTP server on `http://127.0.0.1:3001/health` by default, returns JSON: connection status, uptime, staleness, last message age, reconnect count, memory usage~~ ✅ Live
 2. ~~**Connection staleness detection** (`src/bot/connection.ts`) — tracks `lastMessageReceivedAt` via health module, auto-reconnect if >30 min with no messages. Checks every 5 min. Prevents "connected but deaf" failure mode~~ ✅ Live
 3. ~~**Ollama warm-up ping** (`src/ai/ollama.ts`) — sends `/api/generate` keep-alive with `keep_alive: 15m` every 10 min to prevent model unload. Immediate ping on startup~~ ✅ Live
 4. ~~**SQLite auto-vacuum** (`src/utils/db.ts`) — scheduled daily at 4 AM: prune messages older than 30 days + `VACUUM` to reclaim space~~ ✅ Live

--- a/docs/SETUP_EXAMPLES.md
+++ b/docs/SETUP_EXAMPLES.md
@@ -73,9 +73,9 @@ docker compose logs -f garbanzo
 curl http://127.0.0.1:3001/health
 ```
 
-Deploy a specific release image tag:
+Deploy a specific release image tag (recommended):
 
 ```bash
-APP_VERSION=0.1.1 docker compose pull garbanzo
-APP_VERSION=0.1.1 docker compose up -d
+APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```

--- a/docs/assets/demos/mention-to-response.svg
+++ b/docs/assets/demos/mention-to-response.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Mention to response flow placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7f1e3"/>
+      <stop offset="1" stop-color="#dff2ff"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <text x="70" y="120" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="44" font-weight="700" fill="#124b2a">@mention → response (Placeholder)</text>
+  <text x="70" y="156" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#2d2d2d">Shows the primary interaction loop in group chat.</text>
+
+  <rect x="70" y="220" width="500" height="340" rx="22" fill="#ffffff" stroke="#d7d7d7"/>
+  <text x="110" y="270" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="16" fill="#2d2d2d">Member</text>
+  <path d="M140 300 h360 a18 18 0 0 1 18 18 v50 a18 18 0 0 1 -18 18 h-260 l-60 38 v-38 h-40 a18 18 0 0 1 -18 -18 v-50 a18 18 0 0 1 18 -18 z" fill="#e9f6ee" stroke="#b8e0c6"/>
+  <text x="170" y="340" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="16" fill="#124b2a">@garbanzo</text>
+  <text x="170" y="364" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">what's the plan for tonight?</text>
+
+  <path d="M610 390 C 660 390, 690 390, 740 390" fill="none" stroke="#124b2a" stroke-width="6" stroke-linecap="round"/>
+  <path d="M720 374 L742 390 L720 406" fill="none" stroke="#124b2a" stroke-width="6" stroke-linecap="round"/>
+
+  <rect x="740" y="220" width="390" height="340" rx="22" fill="#ffffff" stroke="#d7d7d7"/>
+  <text x="780" y="270" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="16" fill="#2d2d2d">Garbanzo</text>
+  <path d="M790 300 h300 a18 18 0 0 1 18 18 v84 a18 18 0 0 1 -18 18 h-120 l-60 38 v-38 h-120 a18 18 0 0 1 -18 -18 v-84 a18 18 0 0 1 18 -18 z" fill="#fffaf2" stroke="#ead9bf"/>
+  <text x="820" y="340" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#5a421d">3 ideas in Boston:</text>
+  <text x="820" y="364" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#5a421d">1) trivia  2) ramen  3) walk + cocoa</text>
+
+  <rect x="790" y="460" width="340" height="60" rx="14" fill="#e7f0ff" stroke="#b9d0ff"/>
+  <text x="820" y="496" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#20406b">(this is a placeholder image)</text>
+</svg>

--- a/docs/assets/demos/setup-wizard.svg
+++ b/docs/assets/demos/setup-wizard.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Garbanzo setup wizard demo placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7f1e3"/>
+      <stop offset="1" stop-color="#e2f3e8"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#fbfbfb"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="1100" cy="90" r="140" fill="#cfead8" opacity="0.85"/>
+  <circle cx="104" cy="560" r="220" fill="#f1dfc4" opacity="0.70"/>
+
+  <text x="70" y="92" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="22" fill="#2d2d2d">Garbanzo</text>
+  <text x="70" y="126" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="44" font-weight="700" fill="#124b2a">Setup Wizard (Placeholder)</text>
+  <text x="70" y="160" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#3a3a3a">Replace with a real GIF/screenshot from your terminal run.</text>
+
+  <rect x="70" y="210" width="1060" height="360" rx="18" fill="url(#panel)" stroke="#d7d7d7"/>
+  <rect x="90" y="232" width="1020" height="38" rx="10" fill="#124b2a"/>
+  <circle cx="112" cy="251" r="7" fill="#ff5f56"/>
+  <circle cx="136" cy="251" r="7" fill="#ffbd2e"/>
+  <circle cx="160" cy="251" r="7" fill="#27c93f"/>
+  <text x="190" y="258" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">npm run setup</text>
+
+  <text x="110" y="312" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#2d2d2d">Select platform:</text>
+  <rect x="330" y="294" width="220" height="28" rx="8" fill="#e9f6ee" stroke="#b8e0c6"/>
+  <text x="350" y="313" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#124b2a">whatsapp</text>
+
+  <text x="110" y="362" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#2d2d2d">Provider order:</text>
+  <rect x="330" y="344" width="520" height="28" rx="8" fill="#e9f6ee" stroke="#b8e0c6"/>
+  <text x="350" y="363" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#124b2a">openrouter → openai → ollama</text>
+
+  <text x="110" y="412" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#2d2d2d">Groups:</text>
+  <rect x="330" y="394" width="740" height="120" rx="12" fill="#fffaf2" stroke="#ead9bf"/>
+  <text x="350" y="420" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#5a421d">General (enabled)</text>
+  <text x="350" y="448" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#5a421d">Events (enabled)</text>
+  <text x="350" y="476" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#5a421d">Moderation (owner-only)</text>
+
+  <rect x="960" y="520" width="150" height="34" rx="10" fill="#124b2a"/>
+  <text x="988" y="543" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">Write Files</text>
+</svg>

--- a/docs/assets/screenshots/event-enrichment.svg
+++ b/docs/assets/screenshots/event-enrichment.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Event enrichment placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#dff2ff"/>
+      <stop offset="1" stop-color="#f7f1e3"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <text x="70" y="120" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="44" font-weight="700" fill="#124b2a">Event Enrichment (Placeholder)</text>
+  <text x="70" y="156" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#2d2d2d">Weather + transit + logistics suggestions for a proposed meetup.</text>
+
+  <rect x="70" y="215" width="1060" height="360" rx="20" fill="#ffffff" stroke="#d7d7d7"/>
+
+  <rect x="100" y="245" width="520" height="300" rx="16" fill="#fffaf2" stroke="#ead9bf"/>
+  <text x="130" y="286" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="16" fill="#5a421d">Proposal</text>
+  <text x="130" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">"Coffee + walk in Cambridge on Saturday 2pm"</text>
+
+  <rect x="650" y="245" width="450" height="90" rx="16" fill="#e9f6ee" stroke="#b8e0c6"/>
+  <text x="680" y="282" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#124b2a">Weather</text>
+  <text x="680" y="312" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">52F, light rain, wind 8mph</text>
+  <circle cx="1040" cy="290" r="16" fill="#124b2a" opacity="0.2"/>
+
+  <rect x="650" y="355" width="450" height="90" rx="16" fill="#e7f0ff" stroke="#b9d0ff"/>
+  <text x="680" y="392" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#20406b">Transit</text>
+  <text x="680" y="422" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">Red Line delays (10-15m). Suggest alt routes.</text>
+  <rect x="1000" y="378" width="70" height="26" rx="8" fill="#20406b" opacity="0.14"/>
+
+  <rect x="650" y="465" width="450" height="80" rx="16" fill="#ffffff" stroke="#d7d7d7"/>
+  <text x="680" y="500" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">Logistics</text>
+  <text x="680" y="528" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">Meet outside Harvard Sq. T stop, bring umbrellas.</text>
+</svg>

--- a/docs/assets/screenshots/health-endpoint-json.svg
+++ b/docs/assets/screenshots/health-endpoint-json.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Health endpoint JSON placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0c0f0d"/>
+      <stop offset="1" stop-color="#173e29"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <text x="70" y="110" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="44" font-weight="700" fill="#e7f6ed">/health JSON (Placeholder)</text>
+  <text x="70" y="146" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#cfead8">Used by Uptime Kuma and smoke tests.</text>
+
+  <rect x="70" y="200" width="1060" height="370" rx="18" fill="#0c0f0d" stroke="#2e6a44"/>
+  <text x="100" y="245" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#cfead8">$ curl http://192.168.50.74:3001/health</text>
+
+  <text x="100" y="285" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">{</text>
+  <text x="120" y="315" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">"status": "ok",</text>
+  <text x="120" y="345" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">"stale": false,</text>
+  <text x="120" y="375" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">"uptime": 123456,</text>
+  <text x="120" y="405" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">"memory": { "rss": 210000000 },</text>
+  <text x="120" y="435" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">"backup": { "ok": true }</text>
+  <text x="100" y="465" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#e7f6ed">}</text>
+
+  <rect x="70" y="576" width="1060" height="26" rx="10" fill="#2e6a44" opacity="0.35"/>
+  <text x="90" y="594" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="12" fill="#cfead8">Placeholder image (replace with a real screenshot if desired)</text>
+</svg>

--- a/docs/assets/screenshots/owner-digest.svg
+++ b/docs/assets/screenshots/owner-digest.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Owner daily digest placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#e7f0ff"/>
+      <stop offset="1" stop-color="#f7f1e3"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <text x="70" y="120" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="44" font-weight="700" fill="#124b2a">Owner Daily Digest (Placeholder)</text>
+  <text x="70" y="156" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#2d2d2d">A quick DM-style summary of activity, costs, and issues.</text>
+
+  <rect x="70" y="215" width="1060" height="360" rx="20" fill="#ffffff" stroke="#d7d7d7"/>
+  <rect x="110" y="250" width="1020" height="70" rx="16" fill="#e9f6ee" stroke="#b8e0c6"/>
+  <text x="140" y="292" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="16" fill="#124b2a">Today: 123 messages • 14 AI calls • $0.18 est</text>
+
+  <rect x="110" y="340" width="520" height="210" rx="16" fill="#fffaf2" stroke="#ead9bf"/>
+  <text x="140" y="382" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#5a421d">Highlights</text>
+  <text x="140" y="412" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">- 2 new intros welcomed</text>
+  <text x="140" y="440" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">- 1 meetup plan enriched</text>
+  <text x="140" y="468" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">- 3 polls created</text>
+
+  <rect x="660" y="340" width="470" height="210" rx="16" fill="#e7f0ff" stroke="#b9d0ff"/>
+  <text x="690" y="382" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#20406b">Alerts</text>
+  <text x="690" y="412" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">- none</text>
+  <text x="690" y="440" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">- backups: OK</text>
+  <text x="690" y="468" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">- staleness: false</text>
+</svg>

--- a/docs/assets/screenshots/qr-link.svg
+++ b/docs/assets/screenshots/qr-link.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="WhatsApp QR linking placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#e2f3e8"/>
+      <stop offset="1" stop-color="#f7f1e3"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="1060" cy="520" r="220" fill="#cfead8" opacity="0.7"/>
+
+  <text x="70" y="120" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="44" font-weight="700" fill="#124b2a">WhatsApp QR Linking (Placeholder)</text>
+  <text x="70" y="156" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#2d2d2d">Scan the terminal QR code: WhatsApp → Settings → Linked Devices.</text>
+
+  <rect x="70" y="210" width="520" height="360" rx="18" fill="#ffffff" stroke="#d7d7d7"/>
+  <text x="100" y="252" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="16" fill="#2d2d2d">Terminal</text>
+  <rect x="100" y="276" width="460" height="260" rx="12" fill="#0c0f0d"/>
+  <rect x="140" y="314" width="180" height="180" rx="10" fill="#ffffff"/>
+  <g fill="#0c0f0d">
+    <rect x="156" y="330" width="40" height="40"/>
+    <rect x="212" y="330" width="20" height="20"/>
+    <rect x="244" y="330" width="40" height="40"/>
+    <rect x="156" y="386" width="20" height="20"/>
+    <rect x="188" y="386" width="40" height="40"/>
+    <rect x="244" y="406" width="20" height="20"/>
+    <rect x="276" y="386" width="20" height="20"/>
+    <rect x="156" y="442" width="40" height="40"/>
+    <rect x="212" y="462" width="20" height="20"/>
+    <rect x="244" y="442" width="40" height="40"/>
+  </g>
+  <text x="140" y="542" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="12" fill="#a7a7a7">(placeholder QR pattern)</text>
+
+  <rect x="660" y="210" width="470" height="360" rx="40" fill="#124b2a" opacity="0.12"/>
+  <rect x="700" y="235" width="390" height="310" rx="44" fill="#ffffff" stroke="#d7d7d7"/>
+  <rect x="740" y="270" width="310" height="210" rx="18" fill="#e9f6ee" stroke="#b8e0c6"/>
+  <text x="740" y="520" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#2d2d2d">Camera view (placeholder)</text>
+
+  <path d="M590 392 C 640 360, 650 340, 700 320" fill="none" stroke="#124b2a" stroke-width="6" stroke-linecap="round"/>
+  <path d="M684 314 L706 318 L696 338" fill="none" stroke="#124b2a" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/docs/assets/screenshots/summary-catchup.svg
+++ b/docs/assets/screenshots/summary-catchup.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Catchup summary placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7f1e3"/>
+      <stop offset="1" stop-color="#e2f3e8"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <text x="70" y="120" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="44" font-weight="700" fill="#124b2a">Catchup Summary (Placeholder)</text>
+  <text x="70" y="156" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="18" fill="#2d2d2d">"What did I miss?" recap of recent messages.</text>
+
+  <rect x="70" y="215" width="520" height="360" rx="20" fill="#ffffff" stroke="#d7d7d7"/>
+  <text x="110" y="260" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="16" fill="#2d2d2d">Recent chat (excerpt)</text>
+  <rect x="110" y="285" width="440" height="48" rx="12" fill="#e7f0ff" stroke="#b9d0ff"/>
+  <rect x="110" y="345" width="360" height="48" rx="12" fill="#e9f6ee" stroke="#b8e0c6"/>
+  <rect x="110" y="405" width="420" height="48" rx="12" fill="#fffaf2" stroke="#ead9bf"/>
+  <rect x="110" y="465" width="300" height="48" rx="12" fill="#e7f0ff" stroke="#b9d0ff"/>
+
+  <path d="M610 395 C 660 365, 690 345, 740 315" fill="none" stroke="#124b2a" stroke-width="6" stroke-linecap="round"/>
+  <path d="M722 307 L744 315 L732 335" fill="none" stroke="#124b2a" stroke-width="6" stroke-linecap="round"/>
+
+  <rect x="740" y="215" width="390" height="360" rx="20" fill="#ffffff" stroke="#d7d7d7"/>
+  <text x="780" y="260" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="16" fill="#2d2d2d">Summary</text>
+  <rect x="780" y="285" width="320" height="250" rx="16" fill="#f8fbf9" stroke="#dfe9e3"/>
+  <text x="810" y="330" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#124b2a">- Plans: Saturday meetup @ 2pm</text>
+  <text x="810" y="360" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#124b2a">- Transit: Red Line delays</text>
+  <text x="810" y="390" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#124b2a">- Action: vote on venue poll</text>
+  <text x="810" y="420" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" font-size="14" fill="#124b2a">- Note: bring umbrella</text>
+</svg>


### PR DESCRIPTION
## What
- Remove legacy `garbanzo-macos.tar.gz` assets from the `v0.1.1` GitHub Release (arm64-only macOS going forward).
- Document Docker health endpoint firewalling with an example `DOCKER-USER` allowlist.
- Add a dedicated Docker Hub overview file (`docs/DOCKERHUB_OVERVIEW.md`) and sync it to Docker Hub on each release push.
- Replace README demo placeholder list with real embedded placeholder SVGs and add the assets under `docs/assets/`.
- Small doc fixes for health endpoint wording and prod compose deploy commands.

## Why
- Keeps release assets and docs aligned with the supported arch set.
- Makes the LAN-exposed health endpoint safer by default.
- Ensures Docker Hub overview stays accurate without manual edits.

## Verification
- [x] `npm run check`

## Notes
- Docker Hub categories are still a manual UI setting; this workflow syncs short description + overview content.