### PR TITLE
chore: adopt Prosperity license + commercial policy + OpenClaw lessons

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -94,6 +94,7 @@ jobs:
             org.opencontainers.image.title=Garbanzo
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=https://prosperitylicense.com/versions/3.0.0.html
 
       - name: Generate Docker Hub metadata
         if: ${{ steps.registries.outputs.dockerhub_enabled == 'true' }}
@@ -109,6 +110,7 @@ jobs:
             org.opencontainers.image.title=Garbanzo
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=https://prosperitylicense.com/versions/3.0.0.html
 
       - name: Build and push GHCR image
         uses: docker/build-push-action@v6

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -1,0 +1,31 @@
+# Commercial License
+
+Garbanzo is available under the Prosperity Public License 3.0.0 for noncommercial use and a limited commercial trial.
+
+If you want to use Garbanzo for commercial purposes beyond the trial period, you need a separate commercial license from the contributor.
+
+## What counts as commercial?
+
+Commercial purposes include using Garbanzo:
+
+- inside a for-profit company (internal use counts)
+- as part of a paid product or service
+- to provide consulting, managed hosting, or integrations for clients
+- in any context primarily intended for commercial advantage or private monetary compensation
+
+## How to get a commercial license
+
+Contact:
+
+- Email: jjhickman@pm.me
+- GitHub: https://github.com/jjhickman/garbanzo-bot (open an issue with subject "Commercial license")
+
+Include:
+
+- your company name
+- how you plan to use Garbanzo (which platform, expected users/tenants)
+- whether you need priority support / SLA
+
+## Patents and trademarks
+
+A commercial license may include additional terms for support, warranties, or branding. The Garbanzo name and logos may be subject to trademark-style restrictions even when the code is licensed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Thanks for your interest in contributing! Garbanzo is a community WhatsApp bot built for a Boston-area meetup group, but the codebase is designed to be adaptable for any community.
 
+## License
+
+By contributing to this repository, you agree that your contributions will be licensed under the project license in `LICENSE`.
+
 ## Getting Started
 
 1. Fork the repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ FROM node:25-alpine
 ARG APP_VERSION=0.0.0
 LABEL org.opencontainers.image.title="Garbanzo"
 LABEL org.opencontainers.image.version="$APP_VERSION"
+LABEL org.opencontainers.image.licenses="https://prosperitylicense.com/versions/3.0.0.html"
 
 # dumb-init: proper PID 1 signal handling (SIGTERM → graceful shutdown)
 # ffmpeg: video frame extraction for Claude Vision

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,57 @@
-MIT License
+The Prosperity Public License 3.0.0
 
-Copyright (c) 2026 Josh Hickman
+Contributor: Josh Hickman
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Source Code: https://github.com/jjhickman/garbanzo-bot
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Purpose
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This license allows you to use and share this software for noncommercial purposes for free and to try this software for commercial purposes for thirty days.
+
+Agreement
+
+In order to receive this license, you have to agree to its rules. Those rules are both obligations under that agreement and conditions to your license. Don't do anything with this software that triggers a rule you can't or won't follow.
+
+Notices
+
+Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.
+
+Commercial Trial
+
+Limit your use of this software for commercial purposes to a thirty-day trial period. If you use this software for work, your company gets one trial period for all personnel, not one trial per person.
+
+Contributions Back
+
+Developing feedback, changes, or additions that you contribute back to the contributor on the terms of a standardized public software license such as the Blue Oak Model License 1.0.0, the Apache License 2.0, the MIT license, or the two-clause BSD license doesn't count as use for a commercial purpose.
+
+Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, doesn't count as use for a commercial purpose.
+
+Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution doesn't count as use for a commercial purpose regardless of the source of funding or obligations resulting from the funding.
+
+Defense
+
+Don't make any legal claim against anyone accusing this software, with or without changes, alone or with other technology, of infringing any patent.
+
+Copyright
+
+The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
+
+Patent
+
+The contributor licenses you to do everything with this software that would otherwise infringe any patents they can license or become able to license.
+
+Reliability
+
+The contributor can't revoke this license.
+
+Excuse
+
+You're excused for unknowingly breaking Notices if you take all practical steps to comply within thirty days of learning you broke the rule.
+
+No Liability
+
+As far as the law allows, this software comes as is, without any warranty or condition, and the contributor won't be liable to anyone for any damages related to this software or this license, under any kind of legal claim.

--- a/LICENSE_FAQ.md
+++ b/LICENSE_FAQ.md
@@ -1,0 +1,43 @@
+# License FAQ
+
+Garbanzo is licensed under the Prosperity Public License 3.0.0.
+
+This is a source-available license that:
+
+- allows free use for noncommercial purposes
+- allows a limited commercial trial period (30 days per company)
+- requires a commercial license for ongoing commercial use
+
+This FAQ is a plain-English guide and is not legal advice. The license text in `LICENSE` controls.
+
+## Can I use Garbanzo for personal projects?
+
+Yes. Personal use for hobby projects, private entertainment, research, and learning is noncommercial under the license.
+
+## Can I use Garbanzo for a community group or nonprofit?
+
+Yes. The license explicitly permits use by charitable organizations, educational institutions, public research, public safety/health, environmental protection, and government institutions.
+
+## Can my company use Garbanzo internally?
+
+A short trial is permitted.
+
+Ongoing use inside a for-profit company is commercial use and requires a commercial license.
+
+## Can I offer Garbanzo as a hosted service for clients?
+
+No, not without a commercial license.
+
+## Can I modify Garbanzo?
+
+Yes. You can modify and share changes under the same license terms. If you contribute changes back under a standard public software license (MIT/Apache/Blue Oak/BSD-2), that contribution activity does not count as commercial use.
+
+## What about contractors/consultants?
+
+If you are paid to set up or run Garbanzo for someone else, that is commercial use.
+
+## Why this license?
+
+The goal is to keep Garbanzo accessible to individuals and community organizers while preventing free-riding commercial usage.
+
+If you're building a business on top of Garbanzo, please contact for licensing.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Garbanzo is opinionated around community operations, not just message transport.
 - **Ops-first defaults:** Docker Compose default deploy, branch protections/CI guardrails, credential rotation reminders, and owner-safe approval workflows (`!feedback issue <id>`).
 - **Open and portable roadmap:** tagged Docker releases plus cross-platform native binary bundles as release assets.
 
+## Lessons From OpenClaw (Trust & Maturity)
+
+Garbanzo is the simplified successor to an earlier, more ambitious system ("OpenClaw"). OpenClaw was decommissioned after proving a key lesson: reliability comes from fewer moving parts and clear guardrails, not more services.
+
+What that means in this repo:
+
+- One primary deployable (Docker image) plus optional native bundles; versioned releases are automated
+- Ops-first tooling: `/health` for visibility and `/health/ready` for alerting on disconnect/staleness
+- Boring, inspectable state: SQLite + explicit backups; health reports backup integrity
+- Guardrails by default: CI runs `npm run check` (secrets scan + typecheck + lint + tests)
+
 ## What It Does
 
 Garbanzo connects to WhatsApp via the multi-device Web API, listens for @mentions in group chats, and responds with AI-powered answers, real-time data lookups, and community management tools. The default deployment is Docker Compose with persisted volumes for auth and SQLite data.
@@ -464,6 +475,8 @@ sudo netfilter-persistent save
 
 If Garbanzo is useful for your community, you can support development and operating costs.
 
+Note: Donations (Sponsors/Patreon/Ko-fi) help fund development but do not grant a commercial license. For commercial licensing, see `COMMERCIAL_LICENSE.md`.
+
 - GitHub Sponsors: https://github.com/sponsors/jjhickman
 - (Optional) Configure Patreon/Ko-fi/custom links in `.env`
 
@@ -546,4 +559,10 @@ Use `bash scripts/rotate-gh-secrets.sh --help` for full options.
 
 ## License
 
-[MIT](LICENSE) — Josh Hickman
+Garbanzo is source-available under the [Prosperity Public License 3.0.0](LICENSE):
+
+- Free for noncommercial use (personal + qualifying noncommercial organizations)
+- Commercial use is allowed for a limited 30-day trial
+- Ongoing commercial use requires a commercial license (see `COMMERCIAL_LICENSE.md`)
+
+See `LICENSE_FAQ.md` for examples.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,36 @@
+# Third-Party Notices
+
+Garbanzo depends on third-party open source software.
+
+- JavaScript/TypeScript dependencies are installed via npm and retain their own licenses in `node_modules/`.
+- The Docker image includes OS packages from Alpine Linux repositories.
+
+This file is not an exhaustive license inventory. It is intended to call out notable bundled components and where to find their corresponding source and license terms.
+
+## Docker Image (Alpine Packages)
+
+The official Docker image installs packages using `apk` from Alpine Linux repositories.
+
+Notable packages:
+
+- `ffmpeg` (multimedia processing)
+- `yt-dlp` (YouTube downloader)
+- `dumb-init` (PID 1 init/signal handling)
+- `curl` (health probe)
+
+Alpine package sources and build scripts (aports):
+
+- https://git.alpinelinux.org/aports
+
+Upstream project sources:
+
+- FFmpeg: https://ffmpeg.org/
+- yt-dlp: https://github.com/yt-dlp/yt-dlp
+- dumb-init: https://github.com/Yelp/dumb-init
+- curl: https://curl.se/
+
+## Important Note
+
+Some bundled components (for example, FFmpeg builds) may be available under licenses that carry additional obligations when distributing binaries.
+
+If you plan to redistribute Garbanzo commercially, make sure your distribution process includes appropriate notices and satisfies any relevant copyleft requirements of bundled components.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,18 @@
+# Trademark and Branding
+
+"Garbanzo" and related names/logos used in this repository are intended as project identifiers.
+
+## Summary
+
+- The code is licensed under the terms in `LICENSE`.
+- Names, logos, and other brand identifiers may be used to refer to the project, but should not be used to imply endorsement.
+
+## Commercial use
+
+If you want to use Garbanzo branding in a commercial product or offering, contact the contributor:
+
+- Email: jjhickman@pm.me
+
+## Note
+
+This document is informational and does not grant any trademark rights.

--- a/docs/DOCKERHUB_OVERVIEW.md
+++ b/docs/DOCKERHUB_OVERVIEW.md
@@ -59,6 +59,10 @@ All tags are multi-arch where available:
 - This container persists WhatsApp auth state and SQLite data via Docker volumes.
 - Exposing the health port on your LAN is useful for Uptime Kuma, but you should restrict access to trusted hosts (firewall or reverse proxy).
 
+## License
+
+Garbanzo is source-available under the Prosperity Public License 3.0.0 (see `LICENSE` in the source repository). Noncommercial use is free; commercial use beyond the trial period requires a commercial license.
+
 Source code and docs: https://github.com/jjhickman/garbanzo-bot
 
 Docker Hub note: repository categories are set in the Docker Hub UI (the release workflow syncs overview + short description).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "garbanzo",
       "version": "0.1.1",
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@whiskeysockets/baileys": "^6.7.16",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": ">=20.0.0"
   },
   "author": "Josh Hickman",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@hapi/boom": "^10.0.1",
     "@whiskeysockets/baileys": "^6.7.16",


### PR DESCRIPTION
## What
- Switch project license from MIT to Prosperity Public License 3.0.0.
- Add commercial licensing docs:
  - `COMMERCIAL_LICENSE.md`
  - `LICENSE_FAQ.md`
  - `TRADEMARK.md`
- Add `THIRD_PARTY_NOTICES.md` calling out bundled Docker image components.
- Add an early README section capturing lessons learned from OpenClaw to justify current ops-first, low-complexity design.
- Update Docker image labels and release workflow metadata to include license URL.
- Add a brief contribution licensing note to `CONTRIBUTING.md`.

## Why
You want personal/community self-hosters to use Garbanzo freely, while preventing ongoing for-profit business use without a commercial license.

## Notes
- This is a source-available license (not OSI open source).
- Donations (Sponsors/Patreon/Ko-fi) are separate from commercial licensing.

## Verification
- [x] `npm run check`