### PR TITLE
docs: clarify OpenClaw-inspired stack lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,28 @@ Garbanzo is opinionated around community operations, not just message transport.
 - **Ops-first defaults:** Docker Compose default deploy, branch protections/CI guardrails, credential rotation reminders, and owner-safe approval workflows (`!feedback issue <id>`).
 - **Open and portable roadmap:** tagged Docker releases plus cross-platform native binary bundles as release assets.
 
-## Lessons From OpenClaw (Trust & Maturity)
+## Lessons From Our OpenClaw-Inspired Stack (Trust & Maturity)
 
-Garbanzo is the simplified successor to an earlier, more ambitious system ("OpenClaw"). OpenClaw was decommissioned after proving a key lesson: reliability comes from fewer moving parts and clear guardrails, not more services.
+Before Garbanzo, we ran a more ambitious OpenClaw-inspired setup (many services, lots of automation, and a bigger "agent surface area"). That project taught a key lesson:
 
-What that means in this repo:
+Reliability comes from fewer moving parts and explicit guardrails, not from more integrations.
 
-- One primary deployable (Docker image) plus optional native bundles; versioned releases are automated
-- Ops-first tooling: `/health` for visibility and `/health/ready` for alerting on disconnect/staleness
-- Boring, inspectable state: SQLite + explicit backups; health reports backup integrity
-- Guardrails by default: CI runs `npm run check` (secrets scan + typecheck + lint + tests)
+Important clarification: this section is about our previous deployment and migration learnings, not a critique of the upstream OpenClaw project.
+
+What we kept from OpenClaw-style systems:
+
+- A bias toward useful "skills" (weather/transit/events/summaries) rather than generic chat
+- Tooling that makes the bot operationally observable (health endpoints, backups, logs)
+
+What we intentionally changed in Garbanzo:
+
+- **Single primary deployable:** one Docker image with versioned releases (plus optional native bundles)
+- **Ops-first health semantics:** `GET /health` for visibility and `GET /health/ready` for alerting on disconnect/staleness
+- **Boring, inspectable state:** SQLite + explicit backups; health reports backup integrity
+- **Guardrails by default:** CI runs `npm run check` (secrets scan + typecheck + lint + tests)
+- **Reduced blast radius:** features are reviewed code in-repo (no arbitrary third-party skill execution)
+
+If you're looking for a general-purpose personal assistant with a skill marketplace and broad app integrations, OpenClaw may be a better fit. Garbanzo is optimized for group chat coordination and stable self-hosting.
 
 ## What It Does
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -23,13 +23,13 @@
 | Piper TTS | 10200 | 0.0.0.0 | Text-to-speech (Docker) |
 | OpenWakeWord | 10400 | 0.0.0.0 | Wake word detection (Docker) |
 
-> **Note:** All OpenClaw services (gateway, embeddings, classifiers, ML gateway, task-router,
+> **Note:** All OpenClaw-inspired services (gateway, embeddings, classifiers, ML gateway, task-router,
 > voice-bridge, MBTA SSE/forwarder, webhooks, public-docs) were decommissioned 2026-02-13.
 
 ## Network
 
 - **Tailscale mesh VPN** connects all machines
-- **Tailscale Funnel** disabled (was exposing OpenClaw; can be re-enabled for webhook ingress)
+- **Tailscale Funnel** disabled (was exposing the OpenClaw-inspired stack; can be re-enabled for webhook ingress)
 - LAN: `192.168.50.0/24`
 - NAS NFS: model storage at `/volume2/models/`
 - Backups: encrypted (age) to NAS `/volume1/backups/`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -335,7 +335,7 @@ Research and adopt established, free, trustworthy tools for automated security. 
 
 ## Anti-Patterns to Avoid
 
-These are the mistakes from the OpenClaw setup. Do NOT repeat them:
+These are the mistakes from the earlier OpenClaw-inspired setup. Do NOT repeat them:
 
 1. ❌ **Don't build features for imagined users.** Only add what real members ask for or demonstrably use.
 2. ❌ **Don't add multiple features simultaneously.** One at a time, tested, validated.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -38,7 +38,7 @@ Resolved: UFW enabled with deny-incoming default, allowing SSH + Tailscale (`100
 
 ~~Ollama and OpenClaw were reachable from any device on the LAN.~~
 
-Resolved: Ollama bound to `127.0.0.1`. All OpenClaw services decommissioned (ports 8085, 8089, 8091, 8092, 18789, 18790 closed).
+Resolved: Ollama bound to `127.0.0.1`. All OpenClaw-inspired services decommissioned (ports 8085, 8089, 8091, 8092, 18789, 18790 closed).
 
 Remaining services on `0.0.0.0` (low risk, no sensitive data):
 
@@ -55,9 +55,9 @@ Remaining services on `0.0.0.0` (low risk, no sensitive data):
 
 ### 4. ✅ Tailscale Funnel — DISABLED
 
-~~OpenClaw gateway and docs server were publicly accessible via Tailscale Funnel.~~
+~~OpenClaw-inspired gateway and docs server were publicly accessible via Tailscale Funnel.~~
 
-Resolved: `tailscale funnel off` — no serve config remains. Funnel can be re-enabled later if webhook ingress is needed for the new bot.
+Resolved: `tailscale funnel off` — no serve config remains. Funnel can be re-enabled later if webhook ingress is needed.
 
 ### 5. ✅ Ollama Bound to All Interfaces — FIXED
 
@@ -71,7 +71,7 @@ Resolved: Bound to `127.0.0.1` via systemd override (`/etc/systemd/system/ollama
 
 | Item | Status |
 |------|--------|
-| OpenClaw fully decommissioned (all services stopped + disabled) | ✅ Done |
+| OpenClaw-inspired stack fully decommissioned (all services stopped + disabled) | ✅ Done |
 | ChromaDB bound to localhost (8000) | ✅ Correct |
 | ML services were bound to localhost (now stopped with OpenClaw) | ✅ N/A |
 | Whisper Docker bound to localhost (8090) | ✅ Correct |
@@ -185,7 +185,7 @@ chmod +x .git/hooks/pre-commit
 | 3 | Ollama on `0.0.0.0:11434` | Created `/etc/systemd/system/ollama.service.d/override.conf` with `OLLAMA_HOST=127.0.0.1`, restarted | ✅ `127.0.0.1:11434` |
 | 4 | Tailscale Funnel exposing OpenClaw | `tailscale funnel off` — both `/` and `/docs` routes removed | ✅ No serve config |
 | 5 | Port 18790 on `0.0.0.0` | Stopped + disabled `openclaw-webhooks.service` via `systemctl --user` | ✅ Port closed |
-| — | **Full OpenClaw decommission** | All 10 systemd services stopped + disabled, artifacts preserved to `archive/openclaw/` | ✅ Zero processes, zero ports |
+| — | **Full OpenClaw-inspired stack decommission** | All 10 systemd services stopped + disabled (artifacts preserved out-of-band) | ✅ Zero processes, zero ports |
 
 ### Remaining — Manual Steps
 


### PR DESCRIPTION
## What
- Rewrite the README "Lessons From OpenClaw" section to clarify it refers to our prior OpenClaw-inspired deployment (not the upstream OpenClaw project).
- Align wording in `docs/SECURITY.md`, `docs/INFRASTRUCTURE.md`, and `docs/ROADMAP.md` to use "OpenClaw-inspired" consistently.

## Why
Avoids misrepresenting upstream OpenClaw and makes the trust/maturity case specific to the migration lessons we actually learned.

## Verification
- [x] `npm run check`