### PR TITLE
docs: add AWS CDK path and explicit OpenClaw-inspired comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,28 @@ Reliability comes from fewer moving parts and explicit guardrails, not from more
 
 Important clarification: this section is about our previous deployment and migration learnings, not a critique of the upstream OpenClaw project.
 
-What we kept from OpenClaw-style systems:
+What we kept (inspiration from OpenClaw-style systems):
 
 - A bias toward useful "skills" (weather/transit/events/summaries) rather than generic chat
 - Tooling that makes the bot operationally observable (health endpoints, backups, logs)
+- Cost discipline: explicit routing and fallbacks instead of "just use the biggest model"
 
-What we intentionally changed in Garbanzo:
+What we intentionally changed in Garbanzo (why it's safer for group deployments):
 
-- **Single primary deployable:** one Docker image with versioned releases (plus optional native bundles)
+- **Smaller surface area:** WhatsApp only today (no web control UI, no multi-channel gateway)
+- **Curated features, not a marketplace:** no automatic install/run of third-party skills; features live in-repo and ship via release tags
+- **Group safety defaults:** mention gating + per-group feature allowlists
 - **Ops-first health semantics:** `GET /health` for visibility and `GET /health/ready` for alerting on disconnect/staleness
-- **Boring, inspectable state:** SQLite + explicit backups; health reports backup integrity
-- **Guardrails by default:** CI runs `npm run check` (secrets scan + typecheck + lint + tests)
-- **Reduced blast radius:** features are reviewed code in-repo (no arbitrary third-party skill execution)
+- **Local-first, inspectable state:** SQLite + explicit backups; health reports backup integrity
+- **Security guardrails in CI:** secrets scan + typecheck + lint + tests (`npm run check`)
 
-If you're looking for a general-purpose personal assistant with a skill marketplace and broad app integrations, OpenClaw may be a better fit. Garbanzo is optimized for group chat coordination and stable self-hosting.
+Upstream OpenClaw is explicitly designed as a general personal assistant with a large tool and channel surface, a skills ecosystem, and optional web surfaces. That power is great for single-user assistants, but it increases the amount you must secure.
+
+OpenClaw itself warns its web interface is intended for local use and should not be exposed directly to the public internet:
+
+- https://github.com/openclaw/openclaw/blob/main/SECURITY.md
+
+For a more explicit comparison, see `docs/OPENCLAW_COMPARISON.md`.
 
 ## What It Does
 
@@ -565,6 +573,9 @@ Use `bash scripts/rotate-gh-secrets.sh --help` for full options.
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — Message flow, AI routing, and multimedia pipeline
 - [SETUP_EXAMPLES.md](docs/SETUP_EXAMPLES.md) — Interactive and non-interactive setup recipes
 - [RELEASES.md](docs/RELEASES.md) — Versioning, tag flow, and Docker image release process
+- [AWS.md](docs/AWS.md) — Running Garbanzo on AWS (including CDK EC2 bootstrap)
+- [AWS_MCP.md](docs/AWS_MCP.md) — AWS MCP notes (development/ops tool, not required)
+- [OPENCLAW_COMPARISON.md](docs/OPENCLAW_COMPARISON.md) — OpenClaw-style stack comparison and tradeoffs
 - [CHANGELOG.md](CHANGELOG.md) — Full release history
 - [CONTRIBUTING.md](CONTRIBUTING.md) — How to contribute
 - [AGENTS.md](AGENTS.md) — Coding agent instructions and conventions

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -1,0 +1,95 @@
+# AWS Deployment Notes
+
+This document describes pragmatic ways to run Garbanzo on AWS using your own AWS account.
+
+Garbanzo's WhatsApp transport is Baileys (WhatsApp Web multi-device). That has two operational implications on AWS:
+
+- First boot requires scanning a QR code (you need a way to see logs)
+- Auth state must be persistent (the `baileys_auth/` volume)
+
+Garbanzo also uses SQLite for local state by default. For the simplest, most reliable AWS deployment, prefer a single VM with local disk (EBS) rather than a network filesystem.
+
+## Recommended: EC2 + Docker Compose (Simple + Reliable)
+
+If you like infrastructure-as-code, see `infra/cdk/` for an AWS CDK app that provisions an EC2 instance and bootstraps a pinned Docker Compose deployment.
+
+This is the easiest path that keeps SQLite on a local filesystem and preserves the same Docker Compose runtime as your NAS deployment.
+
+### 1) Create an instance
+
+- Instance type: `t3a.small` (or larger if you enable heavy multimedia)
+- Storage: gp3 EBS (20-50GB)
+- OS: Ubuntu 24.04 LTS
+
+Security Group (inbound):
+
+- Allow SSH (`22/tcp`) from your IP only
+- Optional: allow `/health` port (`3001/tcp`) only from your Uptime Kuma host IP
+- Do not expose WhatsApp/Baileys ports publicly (Garbanzo initiates outbound connections)
+
+### 2) Install Docker
+
+On the instance:
+
+- Install Docker Engine + Compose plugin (Ubuntu official docs)
+- Add your user to the `docker` group
+
+### 3) Deploy Garbanzo
+
+```bash
+git clone https://github.com/jjhickman/garbanzo-bot.git
+cd garbanzo-bot
+cp .env.example .env
+# edit .env and config/groups.json
+
+APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+docker compose logs -f garbanzo
+```
+
+Scan the QR code from the logs on first run.
+
+### 4) Monitoring
+
+- Use `GET /health` for informational status
+- Use `GET /health/ready` for alerting (503 when disconnected/stale)
+
+If you publish port `3001` publicly/within a VPC, restrict it to trusted monitors.
+
+## Option: ECS Fargate + EFS (More Portable, More Moving Parts)
+
+If you want this managed path in the future, we recommend doing EC2 first to prove stability, then migrating once you know your steady-state CPU/memory and data retention needs.
+
+You can run Garbanzo as an ECS task, but you must solve persistence:
+
+- Baileys auth requires persistent storage (EFS works well)
+- SQLite prefers local disk; SQLite on EFS can work but has more risk (latency/locking). For production at scale, consider migrating state to Postgres.
+
+If you still want Fargate:
+
+- Use EFS for `/app/baileys_auth` and `/app/data`
+- Send logs to CloudWatch
+- Use ECS Exec for debugging
+- Ensure the task has outbound internet access (NAT gateway if in private subnets)
+
+## Secrets
+
+For AWS deployments, prefer one of:
+
+- AWS Systems Manager Parameter Store (Standard)
+- AWS Secrets Manager
+
+Inject secrets into the container environment at runtime (avoid writing provider keys to disk where possible).
+
+## Portability Notes
+
+Garbanzo is intentionally designed to be deployable as:
+
+- a single Docker Compose service
+- a single container on managed runtimes
+
+If you want a "business-grade" AWS posture, the big architectural fork is the transport:
+
+- Slack/Teams can be first-class on AWS using official APIs
+- WhatsApp via Baileys remains best-effort community-grade; WhatsApp Business Platform requires a separate adapter and different onboarding

--- a/docs/AWS_MCP.md
+++ b/docs/AWS_MCP.md
@@ -1,0 +1,29 @@
+# AWS MCP (Model Context Protocol) Notes
+
+MCP is useful for *development and operations workflows* (your coding assistant can inspect AWS resources, logs, etc.). It is not required to run Garbanzo.
+
+## Recommended: Official AWS MCP Servers
+
+AWS maintains an official set of MCP servers:
+
+- https://github.com/awslabs/mcp
+
+These are intended to be run locally (or in controlled environments) and can give an MCP-capable assistant access to AWS APIs.
+
+## Security Considerations
+
+- Treat MCP access to AWS like handing the assistant AWS credentials.
+- Prefer short-lived credentials (SSO) and least-privileged IAM policies.
+- Keep a human in the loop for write/destructive actions.
+
+## How We Use This in Garbanzo
+
+Garbanzo itself does not embed MCP today.
+
+For now, MCP is a complementary tool you can use to:
+
+- manage the AWS deployment (EC2, SSM, security groups)
+- troubleshoot CloudWatch logs
+- audit IAM permissions
+
+If we later add an AWS feature to Garbanzo (e.g., "check my AWS bill"), we should implement it as a narrowly scoped feature with explicit IAM permissions, rather than giving the bot broad AWS account control.

--- a/docs/OPENCLAW_COMPARISON.md
+++ b/docs/OPENCLAW_COMPARISON.md
@@ -1,0 +1,78 @@
+# OpenClaw-Inspired Stack vs Garbanzo
+
+This document compares:
+
+- an OpenClaw-style "general personal assistant" approach (multi-channel, tool- and skill-heavy)
+- Garbanzo's approach (curated community operations bot)
+
+It is not a critique of upstream OpenClaw. OpenClaw is an impressive project with explicit security guidance and a broad feature surface.
+
+## What OpenClaw Optimizes For
+
+Based on OpenClaw's own documentation:
+
+- many messaging channels (WhatsApp/Telegram/Slack/Discord/etc.)
+- skills platform + registry
+- automation (cron, webhooks)
+- rich companion apps / control UI
+
+Sources:
+
+- OpenClaw README: https://github.com/openclaw/openclaw
+- OpenClaw SECURITY: https://github.com/openclaw/openclaw/blob/main/SECURITY.md
+
+## Common Pain Points People Report
+
+Examples from community discussions include:
+
+- setup complexity and brittleness
+- unexpected cost spikes / rate limiting
+- context window / memory management issues
+
+Sources:
+
+- Discussion example: https://github.com/openclaw/openclaw/discussions/4220
+- Community runbook: https://github.com/digitalknk/openclaw-runbook
+
+## Skill Ecosystem Tradeoff
+
+OpenClaw has a public skills ecosystem. Community skills are powerful, but they increase the risk that:
+
+- you install something insecure
+- you pull in a large amount of unreviewed code
+
+Source (disclaimer):
+
+- Awesome OpenClaw Skills: https://github.com/VoltAgent/awesome-openclaw-skills
+
+## What Garbanzo Optimizes For
+
+Garbanzo is optimized for stable self-hosting and group chat coordination:
+
+- mention-gated group behavior
+- curated in-repo features (no arbitrary third-party skill marketplace execution)
+- small HTTP surface (`/health` + `/health/ready`)
+- local-first state (SQLite) and explicit backups
+- CI guardrails (secrets scan + typecheck + lint + tests)
+
+## Security and Privacy Posture (Default)
+
+Garbanzo's default approach is intentionally narrow:
+
+- fewer message surfaces (WhatsApp only today)
+- fewer tool execution pathways
+- fewer remote web UIs
+
+This reduces attack surface for group deployments.
+
+OpenClaw's guidance explicitly warns that its web interface is intended for local use and should not be exposed directly to the public internet.
+
+Source:
+
+- https://github.com/openclaw/openclaw/blob/main/SECURITY.md
+
+## When to Choose Which
+
+Pick an OpenClaw-style assistant when you want broad integrations, automation, and a skill ecosystem.
+
+Pick Garbanzo when you want a smaller, auditable, group-ops bot with explicit guardrails and a low operational footprint.

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -1,0 +1,76 @@
+# Garbanzo AWS CDK
+
+This CDK app provisions a simple EC2-based deployment suitable for running Garbanzo with SQLite + persistent Baileys auth.
+
+## Why EC2?
+
+- SQLite works best on local disk (EBS)
+- Baileys auth requires persistence
+- Fargate + EFS is possible but adds complexity and can be harder to debug
+
+## Prereqs
+
+- AWS CLI configured for your account
+- Node.js 20+
+
+## Install
+
+```bash
+cd infra/cdk
+npm install
+```
+
+## Create SSM parameters
+
+Store your `.env` as a SecureString:
+
+```bash
+aws ssm put-parameter \
+  --name /garbanzo/prod/env \
+  --type SecureString \
+  --value "$(cat ../../.env)" \
+  --overwrite
+```
+
+Store `config/groups.json` as a String:
+
+```bash
+aws ssm put-parameter \
+  --name /garbanzo/prod/groups_json \
+  --type String \
+  --value "$(cat ../../config/groups.json)" \
+  --overwrite
+```
+
+## Deploy
+
+```bash
+cd infra/cdk
+
+cdk deploy \
+  -c appVersion=0.1.1 \
+  -c envParamName=/garbanzo/prod/env \
+  -c groupsParamName=/garbanzo/prod/groups_json
+```
+
+Optionally restrict health endpoint:
+
+```bash
+cdk deploy \
+  -c allowedHealthCidr=203.0.113.4/32 \
+  -c appVersion=0.1.1 \
+  -c envParamName=/garbanzo/prod/env \
+  -c groupsParamName=/garbanzo/prod/groups_json
+```
+
+## QR Linking
+
+On first boot, read logs and scan the QR code:
+
+- Use SSM Session Manager (recommended) or SSH if you enable it.
+- Then:
+
+```bash
+cd /opt/garbanzo/garbanzo-bot
+APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f garbanzo
+```

--- a/infra/cdk/bin/garbanzo.ts
+++ b/infra/cdk/bin/garbanzo.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { GarbanzoEc2Stack } from '../lib/garbanzo-ec2-stack.js';
+
+const app = new cdk.App();
+
+new GarbanzoEc2Stack(app, 'GarbanzoEc2Stack', {
+  /*
+   * Set these via `cdk deploy` context or environment:
+   *
+   *   cdk deploy \
+   *     -c appVersion=0.1.1 \
+   *     -c envParamName=/garbanzo/prod/env \
+   *     -c groupsParamName=/garbanzo/prod/groups_json \
+   *     -c allowedHealthCidr=203.0.113.4/32
+   */
+});

--- a/infra/cdk/cdk.json
+++ b/infra/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --loader ts-node/esm bin/garbanzo.ts"
+}

--- a/infra/cdk/lib/garbanzo-ec2-stack.ts
+++ b/infra/cdk/lib/garbanzo-ec2-stack.ts
@@ -1,0 +1,103 @@
+import * as cdk from 'aws-cdk-lib';
+import type { Construct } from 'constructs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+function requireContext(app: cdk.App, key: string): string {
+  const value = app.node.tryGetContext(key);
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Missing required CDK context value: ${key}`);
+  }
+  return value;
+}
+
+function optionalContext(app: cdk.App, key: string): string | undefined {
+  const value = app.node.tryGetContext(key);
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export class GarbanzoEc2Stack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const app = this.node.root as cdk.App;
+
+    const appVersion = optionalContext(app, 'appVersion') ?? '0.1.1';
+    const envParamName = requireContext(app, 'envParamName');
+    const groupsParamName = requireContext(app, 'groupsParamName');
+    const allowedHealthCidr = optionalContext(app, 'allowedHealthCidr');
+
+    // Default VPC keeps this easy to adopt.
+    const vpc = ec2.Vpc.fromLookup(this, 'DefaultVpc', { isDefault: true });
+
+    const sg = new ec2.SecurityGroup(this, 'GarbanzoSg', {
+      vpc,
+      allowAllOutbound: true,
+      description: 'Garbanzo EC2 security group',
+    });
+
+    // Prefer SSM Session Manager instead of opening SSH.
+    // If you want SSH, add an ingress rule explicitly in your fork.
+
+    if (allowedHealthCidr) {
+      sg.addIngressRule(ec2.Peer.ipv4(allowedHealthCidr), ec2.Port.tcp(3001), 'Health endpoint (restricted)');
+    }
+
+    const role = new iam.Role(this, 'GarbanzoInstanceRole', {
+      assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+      description: 'EC2 role for Garbanzo (SSM + Parameter Store reads)',
+    });
+
+    role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
+
+    role.addToPolicy(new iam.PolicyStatement({
+      actions: ['ssm:GetParameter', 'ssm:GetParameters'],
+      resources: [
+        `arn:aws:ssm:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:parameter${envParamName}`,
+        `arn:aws:ssm:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:parameter${groupsParamName}`,
+      ],
+    }));
+
+    // Ubuntu 24.04 LTS
+    const machineImage = ec2.MachineImage.fromSsmParameter(
+      '/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id',
+    );
+
+    const instance = new ec2.Instance(this, 'GarbanzoEc2', {
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3A, ec2.InstanceSize.SMALL),
+      machineImage,
+      securityGroup: sg,
+      role,
+    });
+
+    instance.addUserData(
+      'set -euo pipefail',
+      'export DEBIAN_FRONTEND=noninteractive',
+      'apt-get update -y',
+      'apt-get install -y git awscli ca-certificates curl',
+      'apt-get install -y docker.io docker-compose-plugin',
+      'systemctl enable --now docker',
+      'mkdir -p /opt/garbanzo',
+      'cd /opt/garbanzo',
+      'if [ ! -d garbanzo-bot ]; then git clone https://github.com/jjhickman/garbanzo-bot.git; fi',
+      'cd garbanzo-bot',
+      // Pull secrets/config from Parameter Store.
+      `aws ssm get-parameter --with-decryption --name "${envParamName}" --query 'Parameter.Value' --output text > .env`,
+      `aws ssm get-parameter --name "${groupsParamName}" --query 'Parameter.Value' --output text > config/groups.json`,
+      // Deploy pinned version.
+      `APP_VERSION=${appVersion} docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo`,
+      `APP_VERSION=${appVersion} docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d`,
+    );
+
+    new cdk.CfnOutput(this, 'InstanceId', { value: instance.instanceId });
+    new cdk.CfnOutput(this, 'PublicIp', { value: instance.instancePublicIp });
+    new cdk.CfnOutput(this, 'HealthUrl', {
+      value: `http://${instance.instancePublicIp}:3001/health`,
+      description: 'Only reachable if allowedHealthCidr is set and matches your source IP',
+    });
+  }
+}

--- a/infra/cdk/package.json
+++ b/infra/cdk/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "garbanzo-infra-cdk",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "synth": "cdk synth",
+    "diff": "cdk diff",
+    "deploy": "cdk deploy",
+    "destroy": "cdk destroy"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.198.0",
+    "constructs": "^10.4.2"
+  },
+  "devDependencies": {
+    "aws-cdk": "^2.198.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.3",
+    "@types/node": "^22.10.10"
+  }
+}

--- a/infra/cdk/tsconfig.json
+++ b/infra/cdk/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["bin/**/*.ts", "lib/**/*.ts"]
+}


### PR DESCRIPTION
## What
- Add AWS deployment guidance in `docs/AWS.md`.
- Add AWS MCP notes (development/ops tool, not required for Garbanzo runtime) in `docs/AWS_MCP.md`.
- Add explicit comparison doc `docs/OPENCLAW_COMPARISON.md` focused on tradeoffs and security/privacy surface.
- Make README "OpenClaw-inspired stack" section more explicit about:
  - what we kept from OpenClaw-style systems
  - what we intentionally changed for safer group deployments
  - upstream OpenClaw's own security guidance for web surfaces
- Add a starter AWS CDK app under `infra/cdk/` that provisions an EC2 instance and bootstraps a pinned Docker Compose deploy (SSM Parameter Store for `.env` and `config/groups.json`).

## Sources Used
- OpenClaw security guidance: https://github.com/openclaw/openclaw/blob/main/SECURITY.md
- OpenClaw README: https://github.com/openclaw/openclaw
- Community pain points example: https://github.com/openclaw/openclaw/discussions/4220
- Community skills disclaimer: https://github.com/VoltAgent/awesome-openclaw-skills

## Why
You want stronger, clearer trust framing: Garbanzo is optimized for group chat coordination with a smaller attack surface and fewer implicit/automatic execution paths than general personal assistant stacks.

## Verification
- [x] `npm run check`