### PR TITLE
feat: hardened AWS deploy (private subnets + SSM)

### DIFF
--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -38,8 +38,8 @@ This is the easiest path that keeps SQLite on a local filesystem and preserves t
 
 Security Group (inbound):
 
-- Allow SSH (`22/tcp`) from your IP only
-- Optional: allow `/health` port (`3001/tcp`) only from your Uptime Kuma host IP
+- Recommended: no inbound ports; use SSM Session Manager for access
+- Optional: allow `/health` port (`3001/tcp`) only from a trusted monitor (and only if the instance is reachable)
 - Do not expose WhatsApp/Baileys ports publicly (Garbanzo initiates outbound connections)
 
 ### 2) Install Docker
@@ -69,6 +69,17 @@ Scan the QR code from the logs on first run.
 
 - Use `GET /health` for informational status
 - Use `GET /health/ready` for alerting (503 when disconnected/stale)
+
+Hardened option (recommended): do not open port 3001 at all. Use SSM port forwarding when needed:
+
+```bash
+aws ssm start-session \
+  --target i-xxxxxxxxxxxxxxxxx \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["3001"],"localPortNumber":["3001"]}'
+
+curl http://127.0.0.1:3001/health
+```
 
 If you publish port `3001` publicly/within a VPC, restrict it to trusted monitors.
 

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -59,6 +59,8 @@ After deploy, overwrite both parameters with real values using the AWS CLI.
 
 ## Deploy
 
+Public subnet (default VPC; easiest to start):
+
 ```bash
 cd infra/cdk
 
@@ -68,7 +70,19 @@ cdk deploy \
   -c groupsParamName=/garbanzo/prod/groups_json
 ```
 
-Optionally restrict health endpoint:
+Hardened (private subnets + NAT; no public IP; access via SSM):
+
+```bash
+cdk deploy \
+  -c networkMode=private \
+  -c appVersion=0.1.1 \
+  -c envParamName=/garbanzo/prod/env \
+  -c groupsParamName=/garbanzo/prod/groups_json
+```
+
+Note: private mode creates a new VPC and a NAT gateway (ongoing cost).
+
+Optionally restrict health endpoint (only useful if you have VPC connectivity to the instance):
 
 ```bash
 cdk deploy \


### PR DESCRIPTION
## What
- Add `networkMode=private` option to the CDK stack.
  - Creates a dedicated VPC with private subnets + NAT.
  - Launches the instance in `PRIVATE_WITH_EGRESS` (no public IP).
  - Keeps access via SSM Session Manager.
- Update stack outputs for private vs public mode.
- Update `docs/AWS.md` and `infra/cdk/README.md` with hardened guidance and SSM port forwarding for `/health`.

## Why
Hardens AWS posture by eliminating inbound exposure and relying on SSM + CloudWatch Logs for ops.

## Verification
- [x] `npm --prefix infra/cdk run build`
- [x] `npm run check`