### PR TITLE
docs: add scaling notes and DB dialect config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,12 @@ GITHUB_ISSUES_REPO=jjhickman/garbanzo-bot
 # Ollama endpoint (local inference on Terra)
 OLLAMA_BASE_URL=http://127.0.0.1:11434
 
+# Database
+# sqlite is the only implemented dialect today.
+DB_DIALECT=sqlite
+# For future Postgres support.
+DATABASE_URL=
+
 # Health endpoint (for local probes / Uptime Kuma)
 HEALTH_PORT=3001
 # Default localhost only; set to 0.0.0.0 when monitoring from another host.

--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ Use `bash scripts/rotate-gh-secrets.sh --help` for full options.
 - [SETUP_EXAMPLES.md](docs/SETUP_EXAMPLES.md) — Interactive and non-interactive setup recipes
 - [RELEASES.md](docs/RELEASES.md) — Versioning, tag flow, and Docker image release process
 - [AWS.md](docs/AWS.md) — Running Garbanzo on AWS (including CDK EC2 bootstrap)
+- [SCALING.md](docs/SCALING.md) — Scaling constraints (Baileys + SQLite) and future path
 - [AWS_MCP.md](docs/AWS_MCP.md) — AWS MCP notes (development/ops tool, not required)
 - [OPENCLAW_COMPARISON.md](docs/OPENCLAW_COMPARISON.md) — OpenClaw-style stack comparison and tradeoffs
 - [CHANGELOG.md](CHANGELOG.md) — Full release history

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -11,6 +11,8 @@ Garbanzo also uses SQLite for local state by default. For the simplest, most rel
 
 ## Scaling Note (SQLite + Baileys)
 
+See also: `docs/SCALING.md`
+
 Today, Garbanzo is designed as a single-instance deployment:
 
 - Baileys session state is not designed for active-active multi-replica operation.

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,0 +1,50 @@
+# Scaling Garbanzo
+
+Garbanzo is designed first for stable self-hosting and community operations.
+
+Today, the default architecture is intentionally single-instance:
+
+- WhatsApp transport uses Baileys (WhatsApp Web multi-device)
+- Durable state is SQLite (`data/garbanzo.db`)
+
+This combination is reliable and easy to run, but it is not "horizontal scale" by default.
+
+## What Scales Today
+
+- Vertical scale (bigger CPU/RAM) on one host
+- Higher availability through operational hygiene:
+  - health endpoints (`/health`, `/health/ready`)
+  - backups + integrity checks
+  - well-scoped features and rate limiting
+
+## What Does Not Scale Today
+
+- Active-active replicas on WhatsApp/Baileys
+- Multi-instance writers to SQLite
+
+## AWS Guidance
+
+For AWS, the recommended deployment is EC2 + Docker Compose (see `docs/AWS.md` and `infra/cdk/`).
+
+- Keep state on local EBS
+- Use CloudWatch Logs for visibility
+- Use SSM for access (no inbound ports)
+
+## Path to True Multi-Instance Scale
+
+If you want to support multiple instances reliably, the likely roadmap is:
+
+1) Messaging platforms with official APIs (Slack/Teams/WhatsApp Business Platform)
+2) Move durable state from SQLite to Postgres (RDS)
+3) Introduce queues (SQS) for async workloads where ordering is not critical
+4) Add stateless worker services for expensive/non-interactive workloads
+
+## Database Strategy
+
+SQLite is a deliberate choice for early-stage reliability.
+
+When Postgres becomes necessary:
+
+- introduce a DB backend interface in `src/utils/db-*`
+- migrate state to Postgres with a one-time migration tool
+- maintain a local fallback mode for hobby/community deployments

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -51,6 +51,11 @@ const envSchema = z.object({
   // Infrastructure
   HEALTH_PORT: z.coerce.number().int().min(1).max(65535).default(3001),
   HEALTH_BIND_HOST: z.string().min(1).default('127.0.0.1'),
+
+  // Database
+  DB_DIALECT: z.enum(['sqlite', 'postgres']).default('sqlite'),
+  DATABASE_URL: z.string().optional(),
+
   LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
   OWNER_JID: z.string().min(1, 'OWNER_JID is required — set in .env'),
 });

--- a/src/utils/db-schema.ts
+++ b/src/utils/db-schema.ts
@@ -9,10 +9,15 @@ import Database from 'better-sqlite3';
 import { resolve } from 'path';
 import { mkdirSync } from 'fs';
 import { logger } from '../middleware/logger.js';
-import { PROJECT_ROOT } from './config.js';
+import { PROJECT_ROOT, config } from './config.js';
 
 export const DB_DIR = resolve(PROJECT_ROOT, 'data');
 export const DB_PATH = resolve(DB_DIR, 'garbanzo.db');
+
+if (config.DB_DIALECT !== 'sqlite') {
+  logger.error({ dialect: config.DB_DIALECT }, 'Unsupported DB dialect (only sqlite is implemented)');
+  throw new Error('DB_DIALECT is set to a non-sqlite dialect, but only sqlite is implemented in this build');
+}
 
 // Ensure data directory exists
 mkdirSync(DB_DIR, { recursive: true });


### PR DESCRIPTION
## What
- Add `docs/SCALING.md` describing current scaling constraints (Baileys + SQLite) and the future path.
- Add `DB_DIALECT` + `DATABASE_URL` env vars to config (defaults to SQLite).
- Fail fast at startup if `DB_DIALECT` is set to a non-implemented dialect.
- Update AWS docs and README doc index to reference scaling guidance.

## Why
Sets expectations for AWS portability: EC2 + SQLite is reliable for single-instance deployments today; true multi-instance scale will require a Postgres backend and (likely) official platform adapters.

## Verification
- [x] `npm run check`