### PR TITLE
feat: optional /metrics endpoint for Prometheus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,9 @@ HEALTH_PORT=3001
 # Default localhost only; set to 0.0.0.0 when monitoring from another host.
 HEALTH_BIND_HOST=127.0.0.1
 
+# Prometheus-style metrics (served from the health server at /metrics)
+METRICS_ENABLED=false
+
 # Log level: debug | info | warn | error
 LOG_LEVEL=info
 

--- a/README.md
+++ b/README.md
@@ -442,6 +442,12 @@ Then configure an HTTP monitor in Kuma to check:
 http://<garbanzo-host>:3001/health
 ```
 
+Optional Prometheus scrape (if you enable it):
+
+```text
+http://<garbanzo-host>:3001/metrics
+```
+
 Optional (recommended) second monitor — alert when WhatsApp is disconnected or "connected but deaf":
 
 ```text

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -11,6 +11,8 @@ This combination is reliable and easy to run, but it is not "horizontal scale" b
 
 ## What Scales Today
 
+Prometheus/Grafana-style monitoring can be layered on via `GET /metrics` (optional). This gives you time-series visibility without changing the deployment model.
+
 - Vertical scale (bigger CPU/RAM) on one host
 - Higher availability through operational hygiene:
   - health endpoints (`/health`, `/health/ready`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
   }, 'Configuration loaded');
 
   // Start health check server + memory watchdog for monitoring
-  startHealthServer(config.HEALTH_PORT, config.HEALTH_BIND_HOST);
+  startHealthServer(config.HEALTH_PORT, config.HEALTH_BIND_HOST, { metricsEnabled: config.METRICS_ENABLED });
   startMemoryWatchdog();
 
   // Start Ollama warm-up pings to prevent model unloading

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -51,6 +51,7 @@ const envSchema = z.object({
   // Infrastructure
   HEALTH_PORT: z.coerce.number().int().min(1).max(65535).default(3001),
   HEALTH_BIND_HOST: z.string().min(1).default('127.0.0.1'),
+  METRICS_ENABLED: z.coerce.boolean().default(false),
 
   // Database
   DB_DIALECT: z.enum(['sqlite', 'postgres']).default('sqlite'),


### PR DESCRIPTION
## What
- Add optional Prometheus-style metrics endpoint at `GET /metrics`.
- Controlled by env var `METRICS_ENABLED` (default false).
- Served by the existing health server (no extra port), with the same lightweight rate limiting.
- Includes connection status, staleness, uptime, memory, and backup integrity gauges.
- Adds tests for enabled/disabled behavior.

## Why
This provides time-series observability without requiring a full monitoring stack, and fits the AWS + NAS deployments.

## Verification
- [x] `npm run check`