### PR TITLE
feat: add Google Gemini provider to cloud fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ ANTHROPIC_MODEL=claude-sonnet-4-5-20250514
 OPENROUTER_MODEL=anthropic/claude-sonnet-4-5
 OPENAI_MODEL=gpt-4.1
 
+# Gemini (Google AI Studio key)
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-1.5-flash
+
 # ── WhatsApp ──────────────────────────────────
 # Phone number the bot is registered with (include country code)
 BOT_PHONE_NUMBER=

--- a/src/ai/gemini.ts
+++ b/src/ai/gemini.ts
@@ -1,0 +1,40 @@
+import { logger } from '../middleware/logger.js';
+import { buildProviderRequest, type CloudResponse } from './cloud-providers.js';
+import type { VisionImage } from '../features/media.js';
+
+/** Call the Gemini API (Google AI Studio) via the Generative Language REST endpoint. */
+export async function callGemini(
+  systemPrompt: string,
+  userMessage: string,
+  visionImages?: VisionImage[],
+): Promise<CloudResponse> {
+  const req = buildProviderRequest('gemini', systemPrompt, userMessage, visionImages);
+  if (!req) throw new Error('gemini is not configured (missing GEMINI_API_KEY)');
+
+  const t0 = Date.now();
+  const response = await fetch(req.endpoint, {
+    method: 'POST',
+    headers: req.headers,
+    body: JSON.stringify(req.body),
+  });
+  const latencyMs = Date.now() - t0;
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`gemini API error ${response.status}: ${text}`);
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch (err) {
+    logger.warn({ err, textPreview: text.slice(0, 200) }, 'gemini returned non-JSON response');
+    throw new Error('gemini returned non-JSON response');
+  }
+
+  const out = req.parser(json);
+  if (!out) throw new Error('gemini returned empty response');
+
+  logger.info({ provider: 'gemini', model: req.model, latencyMs }, 'Gemini response received');
+  return { text: out, provider: 'gemini', model: req.model };
+}

--- a/src/features/digest.ts
+++ b/src/features/digest.ts
@@ -81,6 +81,7 @@ function formatDigest(stats: DailyStats): string {
   let totalOllama = 0;
   let totalClaude = 0;
   let totalOpenAI = 0;
+  let totalGemini = 0;
   let totalFlags = 0;
 
   // Sort groups by message count (most active first)
@@ -98,7 +99,7 @@ function formatDigest(stats: DailyStats): string {
       lines.push(`• *${name}* — ${g.messageCount} msgs, ${userCount} active users`);
       if (g.botResponses > 0) {
         lines.push(
-          `  ↳ ${g.botResponses} bot responses (${g.ollamaRouted} Ollama, ${g.claudeRouted} Claude, ${g.openaiRouted} OpenAI)`,
+          `  ↳ ${g.botResponses} bot responses (${g.ollamaRouted} Ollama, ${g.claudeRouted} Claude, ${g.openaiRouted} OpenAI, ${g.geminiRouted} Gemini)`,
         );
       }
       if (g.moderationFlags > 0) {
@@ -110,6 +111,7 @@ function formatDigest(stats: DailyStats): string {
       totalOllama += g.ollamaRouted;
       totalClaude += g.claudeRouted;
       totalOpenAI += g.openaiRouted;
+      totalGemini += g.geminiRouted;
       totalFlags += g.moderationFlags;
     }
   }
@@ -120,13 +122,15 @@ function formatDigest(stats: DailyStats): string {
   lines.push(`• ${totalUsers} unique active users`);
 
   if (totalBotResponses > 0) {
-    const totalCloud = totalClaude + totalOpenAI;
+    const totalCloud = totalClaude + totalOpenAI + totalGemini;
     const ollamaPct = Math.round((totalOllama / totalBotResponses) * 100);
     const cloudPct = Math.max(0, 100 - ollamaPct);
     const openAiShare = totalCloud > 0 ? Math.round((totalOpenAI / totalCloud) * 100) : 0;
+    const geminiShare = totalCloud > 0 ? Math.round((totalGemini / totalCloud) * 100) : 0;
     lines.push(`• ${totalBotResponses} bot responses (${ollamaPct}% Ollama, ${cloudPct}% cloud)`);
     if (totalCloud > 0) {
-      lines.push(`  ↳ cloud split: ${Math.max(0, 100 - openAiShare)}% Claude, ${openAiShare}% OpenAI`);
+      const claudeShare = Math.max(0, 100 - openAiShare - geminiShare);
+      lines.push(`  ↳ cloud split: ${claudeShare}% Claude, ${openAiShare}% OpenAI, ${geminiShare}% Gemini`);
     }
   }
 
@@ -152,6 +156,7 @@ function serializeStats(stats: DailyStats): string {
       ollamaRouted: g.ollamaRouted,
       claudeRouted: g.claudeRouted,
       openaiRouted: g.openaiRouted,
+      geminiRouted: g.geminiRouted,
       moderationFlags: g.moderationFlags,
     };
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -19,11 +19,13 @@ const envSchema = z.object({
   ANTHROPIC_API_KEY: z.string().optional(),
   OPENROUTER_API_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
-  // Comma-separated provider priority order, eg: "openrouter,anthropic,openai"
+  GEMINI_API_KEY: z.string().optional(),
+  // Comma-separated provider priority order, eg: "openrouter,anthropic,openai,gemini"
   AI_PROVIDER_ORDER: z.string().default('openrouter,anthropic,openai'),
   ANTHROPIC_MODEL: z.string().default('claude-sonnet-4-5-20250514'),
   OPENROUTER_MODEL: z.string().default('anthropic/claude-sonnet-4-5'),
   OPENAI_MODEL: z.string().default('gpt-4.1'),
+  GEMINI_MODEL: z.string().default('gemini-1.5-flash'),
 
   // Ollama (local, optional)
   OLLAMA_BASE_URL: z.string().url().default('http://127.0.0.1:11434'),
@@ -72,21 +74,21 @@ if (!parsed.success) {
 }
 
 // Ensure at least one AI provider is configured
-if (!parsed.data.ANTHROPIC_API_KEY && !parsed.data.OPENROUTER_API_KEY && !parsed.data.OPENAI_API_KEY) {
+if (!parsed.data.ANTHROPIC_API_KEY && !parsed.data.OPENROUTER_API_KEY && !parsed.data.OPENAI_API_KEY && !parsed.data.GEMINI_API_KEY) {
   console.error(
-    '❌ At least one AI provider key is required (ANTHROPIC_API_KEY, OPENROUTER_API_KEY, or OPENAI_API_KEY)',
+    '❌ At least one AI provider key is required (ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY)',
   );
   process.exit(1);
 }
 
-const ALLOWED_PROVIDERS = ['openrouter', 'anthropic', 'openai'] as const;
+const ALLOWED_PROVIDERS = ['openrouter', 'anthropic', 'openai', 'gemini'] as const;
 const requestedProviderOrder = parsed.data.AI_PROVIDER_ORDER
   .split(',')
   .map((provider) => provider.trim().toLowerCase())
   .filter(Boolean);
 
 if (requestedProviderOrder.length === 0) {
-  console.error('❌ AI_PROVIDER_ORDER must include at least one provider (openrouter, anthropic, openai)');
+  console.error('❌ AI_PROVIDER_ORDER must include at least one provider (openrouter, anthropic, openai, gemini)');
   process.exit(1);
 }
 
@@ -96,7 +98,7 @@ const invalidProviders = requestedProviderOrder.filter(
 
 if (invalidProviders.length > 0) {
   console.error(`❌ AI_PROVIDER_ORDER contains invalid providers: ${invalidProviders.join(', ')}`);
-  console.error('   Valid providers: openrouter, anthropic, openai');
+  console.error('   Valid providers: openrouter, anthropic, openai, gemini');
   process.exit(1);
 }
 


### PR DESCRIPTION
## What
- Add Google Gemini (AI Studio) as a cloud provider option (`gemini`) in `AI_PROVIDER_ORDER`.
- New env vars:
  - `GEMINI_API_KEY`
  - `GEMINI_MODEL` (default `gemini-1.5-flash`)
- Add `src/ai/gemini.ts` + request builder support in `src/ai/cloud-providers.ts`.
- Update routing, stats, and digest to account for Gemini.

## Notes
- Gemini cost estimation is currently conservative (defaults to $0 until we add configurable/per-model pricing).

## Verification
- [x] `npm run check`