### PR TITLE
docs: multi-platform persona roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ Use `bash scripts/rotate-gh-secrets.sh --help` for full options.
 - [SCALING.md](docs/SCALING.md) — Scaling constraints (Baileys + SQLite) and future path
 - [AWS_MCP.md](docs/AWS_MCP.md) — AWS MCP notes (development/ops tool, not required)
 - [OPENCLAW_COMPARISON.md](docs/OPENCLAW_COMPARISON.md) — OpenClaw-style stack comparison and tradeoffs
+- [MULTI_PLATFORM.md](docs/MULTI_PLATFORM.md) — Multi-platform roadmap (personas per platform)
 - [CHANGELOG.md](CHANGELOG.md) — Full release history
 - [CONTRIBUTING.md](CONTRIBUTING.md) — How to contribute
 - [AGENTS.md](AGENTS.md) — Coding agent instructions and conventions

--- a/docs/MULTI_PLATFORM.md
+++ b/docs/MULTI_PLATFORM.md
@@ -1,0 +1,70 @@
+# Multi-Platform Roadmap (Design)
+
+Garbanzo is WhatsApp-first today.
+
+This doc captures the intended architecture for supporting multiple messaging platforms while:
+
+- preserving per-platform safety/guardrails
+- allowing separate personas per platform
+- keeping the setup wizard coherent
+
+## Goals
+
+- Add official-platform adapters first (Slack/Teams) for enterprise viability.
+- Treat WhatsApp via Baileys as community/self-hosted best-effort.
+- Make platform adapters pluggable without rewriting features.
+
+## Transport Adapter Interface
+
+Each platform adapter should implement a small surface:
+
+- receive inbound messages -> normalized internal message type
+- send text replies
+- provide identity primitives (user id, channel id, display names)
+
+## Persona per Platform
+
+We want a separate persona per platform because:
+
+- tone expectations differ (Slack workspaces vs WhatsApp friend groups)
+- privacy expectations differ (corporate policies)
+- moderation posture differs
+
+Proposed config:
+
+- `PERSONA.md` remains the default.
+- Optional overrides:
+  - `docs/personas/whatsapp.md`
+  - `docs/personas/slack.md`
+  - `docs/personas/discord.md`
+
+Resolution:
+
+- if platform persona exists, use it
+- else fall back to `docs/PERSONA.md`
+- group personas (from `config/groups.json`) are applied last as an addendum
+
+## Setup Wizard Changes
+
+Add prompts/flags:
+
+- `--platform=whatsapp|slack|discord|teams`
+- `--persona-platform-file=./path/to/slack.md` (optional)
+
+Wizard behavior:
+
+- Copies the selected persona file into `docs/personas/<platform>.md`
+- Keeps `docs/PERSONA.md` as the general fallback
+
+## Security & Privacy Considerations
+
+- Platform adapters must not auto-execute tools or webhooks based on untrusted input.
+- Each adapter should have rate limiting and mention gating semantics that match the platform.
+- For enterprise platforms, add audit logs for admin actions.
+
+## Recommended Platform Order
+
+1) Slack (official, straightforward API, clear security model)
+2) Teams (official but more complex app registration)
+3) Discord (popular, but less enterprise driven)
+4) Official WhatsApp Business Platform adapter (separate onboarding)


### PR DESCRIPTION
## What
- Add `docs/MULTI_PLATFORM.md` describing the planned multi-platform adapter architecture.
- Document "persona per platform" strategy and how setup wizard should evolve.
- Link the doc from `README.md`.

## Why
Sets a clear direction for enterprise portability: official platform adapters + explicit personas and guardrails.

## Verification
- [x] `npm run check`