### PR TITLE
refactor: DB backend interface + Postgres skeleton

### DIFF
--- a/src/utils/db-backend.ts
+++ b/src/utils/db-backend.ts
@@ -1,0 +1,56 @@
+import type {
+  DbMessage,
+  ModerationEntry,
+  StrikeSummary,
+  FeedbackEntry,
+  MemoryEntry,
+} from './db.js';
+import type { MemberProfile } from './db.js';
+
+/**
+ * A database backend implements the storage API Garbanzo features depend on.
+ *
+ * This interface intentionally matches the existing `src/utils/db.ts` exports.
+ * SQLite is the only implementation today.
+ */
+export interface DbBackend {
+  // Profiles
+  touchProfile(senderJid: string, groupJid: string): MemberProfile;
+  getProfile(senderJid: string): MemberProfile | null;
+  setProfileInterests(senderJid: string, interests: string[]): boolean;
+  setProfileName(senderJid: string, name: string): boolean;
+  updateActiveGroups(senderJid: string, groupJid: string): boolean;
+  getOptedInProfiles(): MemberProfile[];
+  deleteProfileData(senderJid: string): boolean;
+
+  // Context
+  storeMessage(chatJid: string, sender: string, text: string, timestamp: number): void;
+  getMessages(chatJid: string, limit?: number): DbMessage[];
+
+  // Moderation
+  logModeration(entry: Omit<ModerationEntry, 'id'>): void;
+  getStrikeCount(chatJid: string, sender: string, windowDays?: number): number;
+  getRepeatOffenders(chatJid: string, threshold?: number, windowDays?: number): StrikeSummary[];
+
+  // Daily stats archive
+  saveDailyStats(date: string, json: string): void;
+
+  // Feedback
+  submitFeedback(chatJid: string, senderJid: string, text: string): FeedbackEntry;
+  getOpenFeedback(): FeedbackEntry[];
+  getRecentFeedback(limit?: number): FeedbackEntry[];
+  getFeedbackById(id: number): FeedbackEntry | undefined;
+  setFeedbackStatus(id: number, status: 'open' | 'accepted' | 'rejected' | 'done'): boolean;
+  upvoteFeedback(id: number, senderJid: string): boolean;
+  linkFeedbackToGitHubIssue(id: number, issueNumber: number, issueUrl: string): boolean;
+
+  // Memory
+  addMemory(fact: string, category?: string, source?: string): MemoryEntry;
+  getAllMemories(): MemoryEntry[];
+  deleteMemory(id: number): boolean;
+  searchMemory(keyword: string, limit?: number): MemoryEntry[];
+  formatMemoriesForPrompt(): string;
+
+  // Lifecycle
+  closeDb(): void;
+}

--- a/src/utils/db-postgres.ts
+++ b/src/utils/db-postgres.ts
@@ -1,0 +1,13 @@
+import type { DbBackend } from './db-backend.js';
+
+/**
+ * Postgres backend skeleton.
+ *
+ * This is intentionally not implemented yet. It's here to establish file layout
+ * and to keep the eventual Postgres migration incremental.
+ */
+export function createPostgresBackend(): DbBackend {
+  throw new Error(
+    'Postgres backend is not implemented yet. Set DB_DIALECT=sqlite for now (see docs/SCALING.md).',
+  );
+}

--- a/src/utils/db-sqlite.ts
+++ b/src/utils/db-sqlite.ts
@@ -9,7 +9,8 @@ import { stopMaintenance } from './db-maintenance.js';
 
 // ── Re-export sub-modules ───────────────────────────────────────────
 
-export { db } from './db-schema.js';
+// Do not export the raw SQLite handle from the backend-facing API.
+// Callers should import from `src/utils/db.ts` and use exported functions.
 export {
   touchProfile, getProfile, setProfileInterests, setProfileName,
   updateActiveGroups, getOptedInProfiles,

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -19,10 +19,10 @@ export type {
 export type { MemberProfile } from './db-profiles.js';
 export type { BackupIntegrityStatus } from './db-maintenance.js';
 
-if (config.DB_DIALECT !== 'sqlite') {
-  throw new Error(
-    `DB_DIALECT=${config.DB_DIALECT} is not implemented yet. Use DB_DIALECT=sqlite for now.`,
-  );
+if (config.DB_DIALECT === 'postgres') {
+  const pg = await import('./db-postgres.js');
+  // Initialize to ensure we fail with a clear error message.
+  pg.createPostgresBackend();
 }
 
 const sqlite = await import('./db-sqlite.js');


### PR DESCRIPTION
## What
- Add `src/utils/db-backend.ts` interface describing the storage surface Garbanzo depends on.
- Add `src/utils/db-postgres.ts` skeleton (not implemented yet).
- Keep runtime behavior unchanged: SQLite remains the only working backend.
- Tighten SQLite module exports to avoid leaking the raw DB handle.

## Why
Sets up a clean path to AWS scaling later (RDS/Postgres) without forcing a big rewrite now.

## Verification
- [x] `npm run check`