### PR TITLE
refactor: platform runtime seam + per-platform persona override

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Garbanzo is opinionated around community operations, not just message transport.
 - **Ops-first defaults:** Docker Compose default deploy, branch protections/CI guardrails, credential rotation reminders, and owner-safe approval workflows (`!feedback issue <id>`).
 - **Open and portable roadmap:** tagged Docker releases plus cross-platform native binary bundles as release assets.
 
+## Personas
+
+- Default persona: `docs/PERSONA.md`
+- Optional per-platform persona override: `docs/personas/<platform>.md` (example: `docs/personas/whatsapp.md`)
+
 ## Lessons From Our OpenClaw-Inspired Stack (Trust & Maturity)
 
 Before Garbanzo, we ran a more ambitious OpenClaw-inspired setup (many services, lots of automation, and a bigger "agent surface area"). That project taught a key lesson:

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -233,15 +233,34 @@ async function main() {
     let messagingPlatform = 'whatsapp';
     if (nonInteractive) {
       const requestedPlatform = (cli.options.platform || existing.MESSAGING_PLATFORM || 'whatsapp').trim().toLowerCase();
-      messagingPlatform = requestedPlatform === 'discord' ? 'discord' : 'whatsapp';
+      messagingPlatform = ['whatsapp', 'discord', 'slack', 'teams'].includes(requestedPlatform)
+        ? requestedPlatform
+        : 'whatsapp';
     } else {
       const platformIndex = await promptChoice(
         rl,
         'Messaging platform:',
-        ['WhatsApp (supported now)', 'Discord (planned; runtime support pending)'],
-        existing.MESSAGING_PLATFORM === 'discord' ? 1 : 0,
+        [
+          'WhatsApp (supported now)',
+          'Slack (planned; runtime support pending)',
+          'Teams (planned; runtime support pending)',
+          'Discord (planned; runtime support pending)',
+        ],
+        existing.MESSAGING_PLATFORM === 'slack'
+          ? 1
+          : existing.MESSAGING_PLATFORM === 'teams'
+            ? 2
+            : existing.MESSAGING_PLATFORM === 'discord'
+              ? 3
+              : 0,
       );
-      messagingPlatform = platformIndex === 1 ? 'discord' : 'whatsapp';
+      messagingPlatform = platformIndex === 1
+        ? 'slack'
+        : platformIndex === 2
+          ? 'teams'
+          : platformIndex === 3
+            ? 'discord'
+            : 'whatsapp';
     }
 
     let deployTarget = 'docker';

--- a/src/ai/persona.ts
+++ b/src/ai/persona.ts
@@ -1,7 +1,7 @@
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import { logger } from '../middleware/logger.js';
-import { PROJECT_ROOT } from '../utils/config.js';
+import { PROJECT_ROOT, config } from '../utils/config.js';
 import { truncate } from '../utils/formatting.js';
 import { INTRO_SYSTEM_ADDENDUM, INTRODUCTIONS_JID } from '../features/introductions.js';
 import { getGroupPersona } from '../bot/groups.js';
@@ -10,13 +10,16 @@ import { buildLanguageInstruction } from '../features/language.js';
 import { formatMemoriesForPrompt } from '../utils/db.js';
 
 // Load persona at startup
-const personaPath = resolve(PROJECT_ROOT, 'docs', 'PERSONA.md');
+const defaultPersonaPath = resolve(PROJECT_ROOT, 'docs', 'PERSONA.md');
+const platformPersonaPath = resolve(PROJECT_ROOT, 'docs', 'personas', `${config.MESSAGING_PLATFORM}.md`);
+
 let personaDoc: string;
 try {
-  personaDoc = readFileSync(personaPath, 'utf-8');
+  const chosen = existsSync(platformPersonaPath) ? platformPersonaPath : defaultPersonaPath;
+  personaDoc = readFileSync(chosen, 'utf-8');
 } catch {
   logger.warn('PERSONA.md not found — using minimal system prompt');
-  personaDoc = 'You are Garbanzo Bean, a WhatsApp community bot for a Boston meetup group. Be warm, direct, and helpful.';
+  personaDoc = 'You are Garbanzo Bean, a community chat bot. Be warm, direct, and helpful.';
 }
 
 export interface MessageContext {

--- a/src/platforms/README.md
+++ b/src/platforms/README.md
@@ -1,0 +1,12 @@
+# Platforms
+
+This directory will hold platform-specific runtimes and adapters.
+
+Today:
+
+- WhatsApp is supported via Baileys (`src/platforms/whatsapp/runtime.ts`).
+
+Future:
+
+- Slack/Teams should be built on official APIs.
+- Each platform should be a thin adapter that normalizes inbound messages and calls core routing.

--- a/src/platforms/discord/runtime.ts
+++ b/src/platforms/discord/runtime.ts
@@ -1,0 +1,12 @@
+import { logger } from '../../middleware/logger.js';
+import type { PlatformRuntime } from '../types.js';
+
+export function createDiscordRuntime(): PlatformRuntime {
+  return {
+    platform: 'discord',
+    async start(): Promise<void> {
+      logger.fatal({ platform: 'discord' }, 'Discord runtime is not implemented yet');
+      throw new Error('Discord runtime is not implemented');
+    },
+  };
+}

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -1,0 +1,12 @@
+import { config } from '../utils/config.js';
+import { createWhatsAppRuntime } from './whatsapp/runtime.js';
+import { createDiscordRuntime } from './discord/runtime.js';
+import type { PlatformRuntime } from './types.js';
+
+export function getPlatformRuntime(): PlatformRuntime {
+  if (config.MESSAGING_PLATFORM === 'whatsapp') return createWhatsAppRuntime();
+  if (config.MESSAGING_PLATFORM === 'discord') return createDiscordRuntime();
+
+  // Future platforms are reserved in docs/config; runtime not yet implemented.
+  throw new Error(`Unsupported platform runtime: ${config.MESSAGING_PLATFORM}`);
+}

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -1,0 +1,6 @@
+export type MessagingPlatform = 'whatsapp' | 'discord' | 'slack' | 'teams';
+
+export interface PlatformRuntime {
+  platform: MessagingPlatform;
+  start(): Promise<void>;
+}

--- a/src/platforms/whatsapp/runtime.ts
+++ b/src/platforms/whatsapp/runtime.ts
@@ -1,0 +1,21 @@
+import type { WASocket } from '@whiskeysockets/baileys';
+import { logger } from '../../middleware/logger.js';
+import { startConnection } from '../../bot/connection.js';
+import { registerHandlers } from '../../bot/handlers.js';
+import { registerIntroCatchUp } from '../../features/introductions.js';
+import { scheduleDigest } from '../../features/digest.js';
+import type { PlatformRuntime } from '../types.js';
+
+export function createWhatsAppRuntime(): PlatformRuntime {
+  return {
+    platform: 'whatsapp',
+    async start(): Promise<void> {
+      await startConnection((sock: WASocket) => {
+        registerHandlers(sock);
+        registerIntroCatchUp(sock);
+        scheduleDigest(sock);
+        logger.info('🫘 WhatsApp runtime started');
+      });
+    },
+  };
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -13,7 +13,7 @@ loadDotenv({ path: resolve(PROJECT_ROOT, '.env') });
 
 const envSchema = z.object({
   // Runtime platform
-  MESSAGING_PLATFORM: z.enum(['whatsapp', 'discord']).default('whatsapp'),
+  MESSAGING_PLATFORM: z.enum(['whatsapp', 'discord', 'slack', 'teams']).default('whatsapp'),
 
   // AI — at least one must be set
   ANTHROPIC_API_KEY: z.string().optional(),


### PR DESCRIPTION
## What
- Introduce `src/platforms/` as the home for platform runtimes.
  - WhatsApp runtime wires existing Baileys connection + handlers.
  - Discord runtime is a placeholder that fails fast.
- Update `src/index.ts` to start the selected platform runtime.
- Expand `MESSAGING_PLATFORM` allowed values to include `slack` and `teams` (planned).
- Add per-platform persona override support in `src/ai/persona.ts`:
  - uses `docs/personas/<platform>.md` when present
  - falls back to `docs/PERSONA.md`
- Update setup wizard platform selection to include Slack/Teams (planned).

## Why
Establishes a clean seam for adding Slack/Teams adapters later while keeping WhatsApp behavior unchanged today.

## Verification
- [x] `npm run check`