### PR TITLE
refactor: normalize inbound message shape (no behavior change)

### DIFF
--- a/src/core/inbound-message.ts
+++ b/src/core/inbound-message.ts
@@ -1,0 +1,38 @@
+import type { MessagingPlatform } from '../platforms/types.js';
+
+/**
+ * Normalized inbound message.
+ *
+ * Platform adapters should map their native message types into this shape.
+ * For now, WhatsApp uses this type but still carries the raw native message
+ * for features that need platform-specific operations (media download, quoting).
+ */
+export interface InboundMessage {
+  platform: MessagingPlatform;
+  chatId: string;
+  senderId: string;
+
+  /** True when the message was sent by the bot itself. */
+  fromSelf: boolean;
+
+  /** Status/broadcast messages should be ignored. */
+  isStatusBroadcast: boolean;
+
+  /** Milliseconds since epoch. */
+  timestampMs: number;
+
+  /** Text content if present (after unwrapping platform wrappers). */
+  text: string | null;
+
+  /** Quoted/replied-to text if present. */
+  quotedText?: string;
+
+  /** Platform-native mention identifiers, when available. */
+  mentionedIds?: string[];
+
+  /** True if the message includes visual media. */
+  hasVisualMedia: boolean;
+
+  /** Platform-specific raw message for advanced operations. */
+  raw: unknown;
+}

--- a/src/core/messaging-adapter.ts
+++ b/src/core/messaging-adapter.ts
@@ -1,0 +1,13 @@
+import type { MessagingPlatform } from '../platforms/types.js';
+
+/**
+ * Messaging adapter API.
+ *
+ * This is the minimal surface needed to send responses without exposing
+ * platform-specific SDK types to core routing.
+ */
+export interface MessagingAdapter {
+  platform: MessagingPlatform;
+
+  sendText(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<void>;
+}

--- a/src/platforms/README.md
+++ b/src/platforms/README.md
@@ -9,4 +9,5 @@ Today:
 Future:
 
 - Slack/Teams should be built on official APIs.
-- Each platform should be a thin adapter that normalizes inbound messages and calls core routing.
+- Each platform should normalize inbound messages to `src/core/inbound-message.ts`.
+- Each platform can optionally override persona via `docs/personas/<platform>.md`.

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -1,12 +1,15 @@
 import { config } from '../utils/config.js';
 import { createWhatsAppRuntime } from './whatsapp/runtime.js';
 import { createDiscordRuntime } from './discord/runtime.js';
+import { createSlackRuntime } from './slack/runtime.js';
+import { createTeamsRuntime } from './teams/runtime.js';
 import type { PlatformRuntime } from './types.js';
 
 export function getPlatformRuntime(): PlatformRuntime {
   if (config.MESSAGING_PLATFORM === 'whatsapp') return createWhatsAppRuntime();
   if (config.MESSAGING_PLATFORM === 'discord') return createDiscordRuntime();
+  if (config.MESSAGING_PLATFORM === 'slack') return createSlackRuntime();
+  if (config.MESSAGING_PLATFORM === 'teams') return createTeamsRuntime();
 
-  // Future platforms are reserved in docs/config; runtime not yet implemented.
   throw new Error(`Unsupported platform runtime: ${config.MESSAGING_PLATFORM}`);
 }

--- a/src/platforms/slack/README.md
+++ b/src/platforms/slack/README.md
@@ -1,0 +1,9 @@
+# Slack (planned)
+
+This directory is reserved for the future Slack adapter/runtime.
+
+Plan:
+
+- Use Slack official APIs (Events API + Socket Mode) rather than unofficial transports.
+- Normalize inbound messages to `src/core/inbound-message.ts`.
+- Support a per-platform persona override via `docs/personas/slack.md`.

--- a/src/platforms/slack/runtime.ts
+++ b/src/platforms/slack/runtime.ts
@@ -1,0 +1,12 @@
+import { logger } from '../../middleware/logger.js';
+import type { PlatformRuntime } from '../types.js';
+
+export function createSlackRuntime(): PlatformRuntime {
+  return {
+    platform: 'slack',
+    async start(): Promise<void> {
+      logger.fatal({ platform: 'slack' }, 'Slack runtime is not implemented yet');
+      throw new Error('Slack runtime is not implemented');
+    },
+  };
+}

--- a/src/platforms/teams/README.md
+++ b/src/platforms/teams/README.md
@@ -1,0 +1,9 @@
+# Teams (planned)
+
+This directory is reserved for the future Microsoft Teams adapter/runtime.
+
+Plan:
+
+- Use official Bot Framework / Graph integrations.
+- Normalize inbound messages to `src/core/inbound-message.ts`.
+- Support a per-platform persona override via `docs/personas/teams.md`.

--- a/src/platforms/teams/runtime.ts
+++ b/src/platforms/teams/runtime.ts
@@ -1,0 +1,12 @@
+import { logger } from '../../middleware/logger.js';
+import type { PlatformRuntime } from '../types.js';
+
+export function createTeamsRuntime(): PlatformRuntime {
+  return {
+    platform: 'teams',
+    async start(): Promise<void> {
+      logger.fatal({ platform: 'teams' }, 'Teams runtime is not implemented yet');
+      throw new Error('Teams runtime is not implemented');
+    },
+  };
+}

--- a/src/platforms/whatsapp/adapter.ts
+++ b/src/platforms/whatsapp/adapter.ts
@@ -1,0 +1,12 @@
+import type { WASocket, WAMessage } from '@whiskeysockets/baileys';
+import type { MessagingAdapter } from '../../core/messaging-adapter.js';
+
+export function createWhatsAppAdapter(sock: WASocket): MessagingAdapter {
+  return {
+    platform: 'whatsapp',
+    async sendText(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<void> {
+      const replyTo = options?.replyTo as WAMessage | undefined;
+      await sock.sendMessage(chatId, { text }, replyTo ? { quoted: replyTo } : undefined);
+    },
+  };
+}

--- a/src/platforms/whatsapp/inbound.ts
+++ b/src/platforms/whatsapp/inbound.ts
@@ -1,0 +1,85 @@
+import {
+  type WASocket,
+  type WAMessage,
+  type WAMessageContent,
+  normalizeMessageContent,
+} from '@whiskeysockets/baileys';
+import { hasVisualMedia } from '../../features/media.js';
+import { getSenderJid } from '../../utils/jid.js';
+import type { InboundMessage } from '../../core/inbound-message.js';
+
+export interface WhatsAppInbound extends InboundMessage {
+  platform: 'whatsapp';
+  raw: WAMessage;
+  content: WAMessageContent | undefined;
+}
+
+/**
+ * Unwrap the message content, handling ephemeral/viewOnce/protocol wrappers
+ * that WhatsApp applies in groups with disappearing messages etc.
+ */
+export function unwrapWhatsAppMessage(msg: WAMessage): WAMessageContent | undefined {
+  return normalizeMessageContent(msg.message);
+}
+
+/** Extract text content from unwrapped message content */
+export function extractWhatsAppText(content: WAMessageContent | undefined): string | null {
+  if (!content) return null;
+
+  return (
+    content.conversation ??
+    content.extendedTextMessage?.text ??
+    content.imageMessage?.caption ??
+    content.videoMessage?.caption ??
+    content.documentMessage?.caption ??
+    null
+  );
+}
+
+/** Extract quoted/replied-to text if present */
+export function extractWhatsAppQuotedText(content: WAMessageContent | undefined): string | undefined {
+  const quoted = content?.extendedTextMessage?.contextInfo?.quotedMessage;
+  if (!quoted) return undefined;
+  const unwrapped = normalizeMessageContent(quoted);
+  return extractWhatsAppText(unwrapped) ?? undefined;
+}
+
+/** Extract JIDs mentioned via WhatsApp's native @mention system */
+export function extractWhatsAppMentionedJids(content: WAMessageContent | undefined): string[] | undefined {
+  if (!content) return undefined;
+  const ctx = content.extendedTextMessage?.contextInfo
+    ?? content.imageMessage?.contextInfo
+    ?? content.videoMessage?.contextInfo
+    ?? content.documentMessage?.contextInfo;
+  const jids = ctx?.mentionedJid;
+  if (!jids || jids.length === 0) return undefined;
+  return jids;
+}
+
+export function normalizeWhatsAppInboundMessage(_sock: WASocket, msg: WAMessage): WhatsAppInbound | null {
+  const chatId = msg.key.remoteJid;
+  if (!chatId) return null;
+
+  const content = unwrapWhatsAppMessage(msg);
+  const text = extractWhatsAppText(content);
+  const senderId = getSenderJid(chatId, msg.key.participant);
+
+  const timestampSeconds = typeof msg.messageTimestamp === 'number'
+    ? msg.messageTimestamp
+    : Number(msg.messageTimestamp ?? 0);
+
+  return {
+    platform: 'whatsapp',
+    chatId,
+    senderId,
+    fromSelf: !!msg.key.fromMe,
+    isStatusBroadcast: chatId === 'status@broadcast',
+    timestampMs: timestampSeconds > 0 ? timestampSeconds * 1000 : Date.now(),
+    text,
+    quotedText: extractWhatsAppQuotedText(content),
+    mentionedIds: extractWhatsAppMentionedJids(content),
+    hasVisualMedia: hasVisualMedia(msg),
+    raw: msg,
+    content,
+  };
+}


### PR DESCRIPTION
## What
- Introduce a normalized inbound message type (`src/core/inbound-message.ts`).
- Add a minimal messaging adapter interface (`src/core/messaging-adapter.ts`) and a WhatsApp adapter implementation.
- Add WhatsApp normalization helpers in `src/platforms/whatsapp/inbound.ts`.
- Refactor `src/bot/handlers.ts` to use the WhatsApp normalization helpers and a normalized inbound instance for extraction fields.
- Add placeholder runtimes for Slack/Teams so platform selection is explicit (still unimplemented; fail-fast).

## Why
This is the next incremental step toward multi-platform support:
- reduces direct coupling to Baileys message parsing
- establishes the normalized message shape future adapters will map to

## Behavior
No behavior change intended for WhatsApp.

## Verification
- [x] `npm run check`