### PR TITLE
refactor: core group processor seam (no behavior change)

### DIFF
--- a/src/core/platform-messenger.ts
+++ b/src/core/platform-messenger.ts
@@ -1,0 +1,33 @@
+import type { MessagingAdapter } from './messaging-adapter.js';
+
+export interface DocumentPayload {
+  bytes: Uint8Array;
+  mimetype: string;
+  fileName: string;
+}
+
+export interface AudioPayload {
+  bytes: Uint8Array;
+  mimetype: string;
+  ptt?: boolean;
+}
+
+/**
+ * Platform messenger interface used by core group handling.
+ *
+ * It extends the minimal `MessagingAdapter` with the extra send/delete
+ * operations that some features rely on (polls, documents, audio, deletes).
+ */
+export interface PlatformMessenger extends MessagingAdapter {
+  sendPoll(chatId: string, poll: unknown): Promise<void>;
+
+  /** Returns a platform-specific message ref for optional deletes. */
+  sendTextWithRef(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<unknown>;
+
+  /** Returns a platform-specific message ref for optional deletes. */
+  sendDocument(chatId: string, doc: DocumentPayload): Promise<unknown>;
+
+  sendAudio(chatId: string, audio: AudioPayload, options?: { replyTo?: unknown }): Promise<void>;
+
+  deleteMessage(chatId: string, messageRef: unknown): Promise<void>;
+}

--- a/src/core/process-group-message.ts
+++ b/src/core/process-group-message.ts
@@ -1,0 +1,322 @@
+import { logger } from '../middleware/logger.js';
+import { config } from '../utils/config.js';
+import { matchFeature } from '../features/router.js';
+import { handlePoll, isDuplicatePoll, recordPoll } from '../features/polls.js';
+import { handleCharacter } from '../features/character.js';
+import { handleFeedbackSubmit, handleUpvote } from '../features/feedback.js';
+import { handleVoiceCommand, formatVoiceList, textToSpeech, isTTSAvailable } from '../features/voice.js';
+import { extractUrls, processUrl } from '../features/links.js';
+import { isSoftMuted } from '../features/moderation.js';
+import { checkRateLimit, recordResponse } from '../middleware/rate-limit.js';
+import { recordBotResponse } from '../middleware/stats.js';
+import { queueRetry } from '../middleware/retry.js';
+import { getResponse } from '../bot/response-router.js';
+import { isFeatureEnabled } from '../bot/groups.js';
+import type { VisionImage } from '../features/media.js';
+import type { PlatformMessenger } from './platform-messenger.js';
+
+export interface ProcessGroupMessageParams {
+  messenger: PlatformMessenger;
+
+  chatId: string;
+  senderId: string;
+  groupName: string;
+
+  /** Mention-stripped query string (optionally enriched, e.g. with URL context). */
+  query: string;
+
+  quotedText?: string;
+  messageId?: string;
+  replyTo?: unknown;
+
+  visionImages?: VisionImage[];
+}
+
+/**
+ * Core group message processor.
+ *
+ * This function contains feature routing and AI response generation logic
+ * without relying on platform SDK types.
+ */
+export async function processGroupMessage(params: ProcessGroupMessageParams): Promise<void> {
+  const {
+    messenger,
+    chatId,
+    senderId,
+    groupName,
+    query,
+    quotedText,
+    messageId,
+    replyTo,
+    visionImages,
+  } = params;
+
+  // Soft-muted users get silently ignored
+  if (isSoftMuted(senderId)) {
+    logger.debug({ senderId, group: chatId }, 'Ignoring soft-muted user');
+    return;
+  }
+
+  // Rate limit check
+  const rateLimited = checkRateLimit(senderId, chatId);
+  if (rateLimited) {
+    await messenger.sendText(chatId, rateLimited, { replyTo });
+    return;
+  }
+
+  const featureCheck = matchFeature(query);
+
+  // Feedback commands — !suggest, !bug, !upvote
+  if (featureCheck?.feature === 'feedback' && isFeatureEnabled(chatId, 'feedback')) {
+    await handleFeedbackCommand({
+      messenger,
+      chatId,
+      senderId,
+      query,
+      replyTo,
+    });
+    return;
+  }
+
+  // Poll command — native poll when available
+  if (featureCheck?.feature === 'poll' && isFeatureEnabled(chatId, 'poll')) {
+    await handlePollCommand({
+      messenger,
+      chatId,
+      senderId,
+      featureQuery: featureCheck.query,
+      replyTo,
+    });
+    return;
+  }
+
+  // Character command — text summary + PDF
+  if (featureCheck?.feature === 'character' && isFeatureEnabled(chatId, 'character')) {
+    await handleCharacterCommand({
+      messenger,
+      chatId,
+      featureQuery: featureCheck.query,
+      replyTo,
+    });
+    return;
+  }
+
+  // Voice command (!voice) — TTS reply
+  if (featureCheck?.feature === 'voice' && isFeatureEnabled(chatId, 'voice')) {
+    await handleVoiceFeature({
+      messenger,
+      chatId,
+      featureQuery: featureCheck.query,
+      quotedText,
+      replyTo,
+    });
+    return;
+  }
+
+  // URL context enrichment
+  let urlContext = '';
+  const urls = extractUrls(query);
+  if (urls.length > 0) {
+    const urlSummary = await processUrl(urls[0]);
+    if (urlSummary) {
+      urlContext = `\n\n[Shared link context]\n${urlSummary}`;
+    }
+  }
+
+  const enrichedQuery = urlContext ? query + urlContext : query;
+
+  const response = await getResponse(enrichedQuery, {
+    groupName,
+    groupJid: chatId,
+    senderJid: senderId,
+    quotedText,
+  }, visionImages);
+
+  if (response) {
+    // If AI returned the error fallback, queue for retry instead of sending error
+    if (response.includes('I hit a snag')) {
+      queueRetry({
+        groupJid: chatId,
+        senderJid: senderId,
+        query,
+        quotedMsgId: messageId,
+        timestamp: Date.now(),
+      });
+      return;
+    }
+
+    recordBotResponse(chatId);
+    recordResponse(senderId, chatId);
+    await messenger.sendText(chatId, response, { replyTo });
+  }
+}
+
+async function handleFeedbackCommand(params: {
+  messenger: PlatformMessenger;
+  chatId: string;
+  senderId: string;
+  query: string;
+  replyTo?: unknown;
+}): Promise<void> {
+  const { messenger, chatId, senderId, query, replyTo } = params;
+
+  const bangWord = query.trim().split(/\s+/)[0].toLowerCase().replace('!', '');
+  const feedbackArgs = query.trim().slice(query.trim().indexOf(' ') + 1).trim();
+  const isBareCommand = !query.trim().includes(' ');
+
+  if (bangWord === 'suggest' || bangWord === 'suggestion') {
+    const result = handleFeedbackSubmit('suggestion', isBareCommand ? '' : feedbackArgs, senderId, chatId);
+    await messenger.sendText(chatId, result.response, { replyTo });
+    if (result.ownerAlert) {
+      try {
+        await messenger.sendText(config.OWNER_JID, result.ownerAlert);
+      } catch (err) {
+        logger.error({ err, ownerJid: config.OWNER_JID, senderId, chatId, type: 'suggestion' }, 'Failed to forward feedback to owner');
+      }
+    }
+    recordBotResponse(chatId);
+    recordResponse(senderId, chatId);
+    return;
+  }
+
+  if (bangWord === 'bug') {
+    const result = handleFeedbackSubmit('bug', isBareCommand ? '' : feedbackArgs, senderId, chatId);
+    await messenger.sendText(chatId, result.response, { replyTo });
+    if (result.ownerAlert) {
+      try {
+        await messenger.sendText(config.OWNER_JID, result.ownerAlert);
+      } catch (err) {
+        logger.error({ err, ownerJid: config.OWNER_JID, senderId, chatId, type: 'bug' }, 'Failed to forward feedback to owner');
+      }
+    }
+    recordBotResponse(chatId);
+    recordResponse(senderId, chatId);
+    return;
+  }
+
+  if (bangWord === 'upvote') {
+    const response = handleUpvote(isBareCommand ? '' : feedbackArgs, senderId);
+    await messenger.sendText(chatId, response, { replyTo });
+    recordBotResponse(chatId);
+    recordResponse(senderId, chatId);
+    return;
+  }
+
+  if (bangWord === 'feedback') {
+    await messenger.sendText(chatId, [
+      '💡 *Submit feedback:*',
+      '  !suggest <your idea>',
+      '  !bug <what went wrong>',
+      '  !upvote <id>',
+    ].join('\n'), { replyTo });
+  }
+}
+
+async function handlePollCommand(params: {
+  messenger: PlatformMessenger;
+  chatId: string;
+  senderId: string;
+  featureQuery: string;
+  replyTo?: unknown;
+}): Promise<void> {
+  const { messenger, chatId, senderId, featureQuery, replyTo } = params;
+
+  const pollResult = handlePoll(featureQuery);
+  if (typeof pollResult === 'string') {
+    await messenger.sendText(chatId, pollResult, { replyTo });
+    return;
+  }
+
+  if (isDuplicatePoll(chatId, pollResult.name)) {
+    await messenger.sendText(chatId, '🗳️ A similar poll was already posted in the last hour.', { replyTo });
+    return;
+  }
+
+  await messenger.sendPoll(chatId, pollResult);
+  recordPoll(chatId, pollResult.name);
+  recordBotResponse(chatId);
+  recordResponse(senderId, chatId);
+}
+
+async function handleCharacterCommand(params: {
+  messenger: PlatformMessenger;
+  chatId: string;
+  featureQuery: string;
+  replyTo?: unknown;
+}): Promise<void> {
+  const { messenger, chatId, featureQuery, replyTo } = params;
+
+  const charResult = await handleCharacter(featureQuery);
+  if (typeof charResult === 'string') {
+    await messenger.sendText(chatId, charResult, { replyTo });
+    return;
+  }
+
+  const summaryRef = await messenger.sendTextWithRef(chatId, charResult.summary, { replyTo });
+  const pdfRef = await messenger.sendDocument(chatId, {
+    bytes: charResult.pdfBytes,
+    mimetype: 'application/pdf',
+    fileName: charResult.fileName,
+  });
+
+  // If validation flagged empty fields, retry once and delete old messages
+  if (charResult.hasEmptyFields) {
+    logger.warn({ fileName: charResult.fileName }, 'Character PDF had empty fields — regenerating');
+    const retryResult = await handleCharacter(featureQuery);
+    if (typeof retryResult !== 'string' && !retryResult.hasEmptyFields) {
+      await messenger.deleteMessage(chatId, summaryRef);
+      await messenger.deleteMessage(chatId, pdfRef);
+
+      await messenger.sendText(chatId, retryResult.summary, { replyTo });
+      await messenger.sendDocument(chatId, {
+        bytes: retryResult.pdfBytes,
+        mimetype: 'application/pdf',
+        fileName: retryResult.fileName,
+      });
+
+      logger.info({ fileName: retryResult.fileName }, 'Character PDF retry sent, old messages deleted');
+    }
+  }
+
+  recordBotResponse(chatId);
+  recordResponse(config.OWNER_JID, chatId);
+}
+
+async function handleVoiceFeature(params: {
+  messenger: PlatformMessenger;
+  chatId: string;
+  featureQuery: string;
+  quotedText?: string;
+  replyTo?: unknown;
+}): Promise<void> {
+  const { messenger, chatId, featureQuery, quotedText, replyTo } = params;
+
+  const voiceCmd = handleVoiceCommand(featureQuery);
+  if (voiceCmd.action === 'list') {
+    await messenger.sendText(chatId, formatVoiceList(), { replyTo });
+    return;
+  }
+
+  if (!isTTSAvailable()) {
+    await messenger.sendText(chatId, '🎙️ Voice feature is not configured on this server.', { replyTo });
+    return;
+  }
+
+  const textToSpeak = quotedText ?? featureQuery;
+  if (!textToSpeak || textToSpeak === voiceCmd.voiceId) {
+    await messenger.sendText(chatId, '🎙️ Reply to a message with `!voice` to hear it spoken, or `!voice list` for available voices.', { replyTo });
+    return;
+  }
+
+  const audio = await textToSpeech(textToSpeak, voiceCmd.voiceId);
+  if (!audio) {
+    await messenger.sendText(chatId, '🎙️ Voice generation failed. Try again.', { replyTo });
+    return;
+  }
+
+  await messenger.sendAudio(chatId, {
+    bytes: audio,
+    mimetype: 'audio/ogg; codecs=opus',
+    ptt: true,
+  }, { replyTo });
+}

--- a/src/platforms/whatsapp/adapter.ts
+++ b/src/platforms/whatsapp/adapter.ts
@@ -1,12 +1,47 @@
-import type { WASocket, WAMessage } from '@whiskeysockets/baileys';
-import type { MessagingAdapter } from '../../core/messaging-adapter.js';
+import type { WASocket, WAMessage, PollMessageOptions, WAMessageKey } from '@whiskeysockets/baileys';
+import type { PlatformMessenger } from '../../core/platform-messenger.js';
 
-export function createWhatsAppAdapter(sock: WASocket): MessagingAdapter {
+export function createWhatsAppAdapter(sock: WASocket): PlatformMessenger {
   return {
     platform: 'whatsapp',
+
     async sendText(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<void> {
       const replyTo = options?.replyTo as WAMessage | undefined;
       await sock.sendMessage(chatId, { text }, replyTo ? { quoted: replyTo } : undefined);
+    },
+
+    async sendTextWithRef(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<unknown> {
+      const replyTo = options?.replyTo as WAMessage | undefined;
+      return await sock.sendMessage(chatId, { text }, replyTo ? { quoted: replyTo } : undefined);
+    },
+
+    async sendPoll(chatId: string, poll: unknown): Promise<void> {
+      // Accept the core's opaque poll object and assert to Baileys poll payload.
+      await sock.sendMessage(chatId, { poll: poll as PollMessageOptions });
+    },
+
+    async sendDocument(chatId: string, doc: { bytes: Uint8Array; mimetype: string; fileName: string }): Promise<unknown> {
+      return await sock.sendMessage(chatId, {
+        document: Buffer.from(doc.bytes),
+        mimetype: doc.mimetype,
+        fileName: doc.fileName,
+      });
+    },
+
+    async sendAudio(chatId: string, audio: { bytes: Uint8Array; mimetype: string; ptt?: boolean }, options?: { replyTo?: unknown }): Promise<void> {
+      const replyTo = options?.replyTo as WAMessage | undefined;
+      await sock.sendMessage(chatId, {
+        audio: Buffer.from(audio.bytes),
+        mimetype: audio.mimetype,
+        ptt: audio.ptt ?? true,
+      }, replyTo ? { quoted: replyTo } : undefined);
+    },
+
+    async deleteMessage(chatId: string, messageRef: unknown): Promise<void> {
+      if (!messageRef || typeof messageRef !== 'object') return;
+      const maybe = messageRef as { key?: unknown };
+      if (!maybe.key) return;
+      await sock.sendMessage(chatId, { delete: maybe.key as WAMessageKey });
     },
   };
 }

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -33,7 +33,8 @@ function mockHandlerDeps(): HandlerMocks {
   }));
 
   vi.doMock('../src/utils/config.js', () => ({
-    config: { OWNER_JID: 'owner@s.whatsapp.net' },
+    PROJECT_ROOT: '/tmp',
+    config: { OWNER_JID: 'owner@s.whatsapp.net', MESSAGING_PLATFORM: 'whatsapp' },
   }));
 
   vi.doMock('../src/utils/jid.js', () => ({


### PR DESCRIPTION
## What
- Add `PlatformMessenger` interface (`src/core/platform-messenger.ts`) describing the richer messaging capabilities some features need (polls, documents, deletes, audio).
- Add `processGroupMessage` scaffold (`src/core/process-group-message.ts`) that contains platform-agnostic feature routing and AI response dispatch.
  - Not wired into runtime yet (WhatsApp continues using `src/bot/group-handler.ts`).
- Extend WhatsApp adapter to implement `PlatformMessenger` while keeping existing `sendText` behavior unchanged.
- Test fix: include `PROJECT_ROOT` export in `tests/handlers.test.ts` config mock.

## Why
This sets up the seam to make group feature routing platform-agnostic so future Slack/Teams adapters can reuse it.

## Behavior
No runtime behavior change intended.

## Verification
- [x] `npm run check`