### PR TITLE
refactor: inject response router into core group processor

### DIFF
--- a/src/bot/group-handler.ts
+++ b/src/bot/group-handler.ts
@@ -8,6 +8,7 @@ import {
   extractWhatsAppQuotedText as extractQuotedText,
 } from '../platforms/whatsapp/inbound.js';
 import { processGroupMessage } from '../core/process-group-message.js';
+import { getResponse } from './response-router.js';
 import { createWhatsAppAdapter } from '../platforms/whatsapp/adapter.js';
 
 /**
@@ -73,6 +74,7 @@ export async function handleGroupMessage(
     groupName,
     query,
     isFeatureEnabled,
+    getResponse,
     quotedText: extractQuotedText(content),
     messageId: msg.key.id ?? undefined,
     replyTo: msg,

--- a/src/core/process-group-message.ts
+++ b/src/core/process-group-message.ts
@@ -10,7 +10,7 @@ import { isSoftMuted } from '../features/moderation.js';
 import { checkRateLimit, recordResponse } from '../middleware/rate-limit.js';
 import { recordBotResponse } from '../middleware/stats.js';
 import { queueRetry } from '../middleware/retry.js';
-import { getResponse } from '../bot/response-router.js';
+import type { MessageContext } from '../ai/persona.js';
 import type { VisionImage } from '../features/media.js';
 import type { PlatformMessenger } from './platform-messenger.js';
 
@@ -25,6 +25,7 @@ export interface ProcessGroupMessageParams {
   query: string;
 
   isFeatureEnabled: (chatId: string, feature: string) => boolean;
+  getResponse: (query: string, ctx: MessageContext, visionImages?: VisionImage[]) => Promise<string | null>;
 
   quotedText?: string;
   messageId?: string;
@@ -51,6 +52,7 @@ export async function processGroupMessage(params: ProcessGroupMessageParams): Pr
     replyTo,
     visionImages,
     isFeatureEnabled,
+    getResponse,
   } = params;
 
   // Soft-muted users get silently ignored

--- a/tests/core-group-parity.test.ts
+++ b/tests/core-group-parity.test.ts
@@ -159,6 +159,7 @@ describe('Core group processor parity (WhatsApp)', () => {
       groupName: 'General',
       query: '!poll What day? / Fri / Sat',
       isFeatureEnabled: () => true,
+      getResponse: async () => 'ai response',
       replyTo: msg,
     });
 
@@ -224,6 +225,7 @@ describe('Core group processor parity (WhatsApp)', () => {
       groupName: 'General',
       query: text,
       isFeatureEnabled: () => true,
+      getResponse: async () => 'ai response',
       replyTo: msg,
     });
 


### PR DESCRIPTION
## Objective
Continue reducing core group processing dependencies on bot modules by injecting the response router instead of importing it directly.

Closes: n/a

## Problem
- `src/core/process-group-message.ts` imported `getResponse` from `src/bot/response-router.ts`, which makes the core layer depend on bot wiring.

## Solution
- Add `getResponse` as an injected dependency on `processGroupMessage` params.
- Pass `getResponse` from `src/bot/group-handler.ts`.
- Update parity tests to provide a stub `getResponse`.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:
- n/a (refactor only)

## Risk and Rollback
- Risk level: low
- Primary risk: missed callsite passing `getResponse` (caught by typecheck/tests).
- Rollback approach: revert this PR.

## Operational and Security Checklist
- [x] No secrets or credentials added to tracked files
- [x] Health/monitoring implications reviewed (no change)
- [x] Performance/cost implications reviewed (no change)

## Docs and Communication
- [x] `README.md` updated (n/a)
- [x] Relevant `docs/*.md` updated (n/a)
- [x] Release note/customer-facing summary prepared (n/a)

## Reviewer Focus Areas
1. `src/core/process-group-message.ts` dependency injection surface
2. `src/bot/group-handler.ts` wiring