### PR TITLE
refactor: inject passive intro/events handlers into core inbound

### DIFF
--- a/src/platforms/whatsapp/processor.ts
+++ b/src/platforms/whatsapp/processor.ts
@@ -3,6 +3,8 @@ import { logger } from '../../middleware/logger.js';
 import { markMessageReceived } from '../../middleware/health.js';
 import { isVoiceMessage, downloadVoiceAudio } from '../../features/media.js';
 import { transcribeAudio } from '../../features/voice.js';
+import { handleIntroduction, INTRODUCTIONS_JID } from '../../features/introductions.js';
+import { handleEventPassive, EVENTS_JID } from '../../features/events.js';
 import { config } from '../../utils/config.js';
 import { isGroupEnabled } from '../../bot/groups.js';
 import { handleOwnerDM } from '../../bot/owner-commands.js';
@@ -67,5 +69,9 @@ export async function processWhatsAppRawMessage(sock: WASocket, msg: WAMessage):
   }, {
     ownerId: config.OWNER_JID,
     isGroupEnabled,
+    introductionsChatId: INTRODUCTIONS_JID,
+    eventsChatId: EVENTS_JID,
+    handleIntroduction,
+    handleEventPassive,
   });
 }


### PR DESCRIPTION
## Objective
Make the core inbound pipeline fully independent of feature modules that depend on bot group config by injecting passive intro/events handlers from the platform layer.

Closes: n/a

## Problem
- `src/core/process-inbound-message.ts` imported `INTRODUCTIONS_JID`/`handleIntroduction` and `EVENTS_JID`/`handleEventPassive`.
- Those feature modules depend on bot group config (`GROUP_IDS`), so core was indirectly coupled to bot configuration.

## Solution
- Extend `CoreInboundEnv` with:
  - `introductionsChatId`, `eventsChatId`
  - `handleIntroduction`, `handleEventPassive`
- Use injected values for:
  - stale-message exception for Introductions
  - passive Introductions + Events group handling
- Wire WhatsApp processor to provide these values from existing feature exports.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`

## Risk and Rollback
- Risk level: low
- Primary risk: mis-wiring of env fields (caught by typecheck/tests)
- Rollback approach: revert this PR

## Operational and Security Checklist
- [x] No secrets or credentials added to tracked files

## Docs and Communication
- [x] `README.md` updated (n/a)
- [x] Relevant `docs/*.md` updated (n/a)
- [x] Release note/customer-facing summary prepared (n/a)

## Reviewer Focus Areas
1. `src/core/process-inbound-message.ts` env usage for passive handlers
2. `src/platforms/whatsapp/processor.ts` wiring from feature exports