### PR TITLE
refactor: resolve special group JIDs from config

### DIFF
--- a/src/bot/groups.ts
+++ b/src/bot/groups.ts
@@ -45,6 +45,17 @@ export function getGroupName(jid: string): string {
   return GROUP_IDS[jid]?.name ?? 'Unknown Group';
 }
 
+/**
+ * Find an enabled group JID by its configured name.
+ * Returns null if not found or not enabled.
+ */
+export function getEnabledGroupJidByName(name: string): string | null {
+  for (const [jid, cfg] of Object.entries(GROUP_IDS)) {
+    if (cfg.name === name && cfg.enabled) return jid;
+  }
+  return null;
+}
+
 /** Check if a group requires @mention to respond */
 export function requiresMention(jid: string): boolean {
   return GROUP_IDS[jid]?.requireMention ?? true;

--- a/src/platforms/whatsapp/processor.ts
+++ b/src/platforms/whatsapp/processor.ts
@@ -3,10 +3,10 @@ import { logger } from '../../middleware/logger.js';
 import { markMessageReceived } from '../../middleware/health.js';
 import { isVoiceMessage, downloadVoiceAudio } from '../../features/media.js';
 import { transcribeAudio } from '../../features/voice.js';
-import { handleIntroduction, INTRODUCTIONS_JID } from '../../features/introductions.js';
-import { handleEventPassive, EVENTS_JID } from '../../features/events.js';
+import { handleIntroduction } from '../../features/introductions.js';
+import { handleEventPassive } from '../../features/events.js';
 import { config } from '../../utils/config.js';
-import { isGroupEnabled } from '../../bot/groups.js';
+import { isGroupEnabled, getEnabledGroupJidByName } from '../../bot/groups.js';
 import { handleOwnerDM } from '../../bot/owner-commands.js';
 import { handleGroupMessage } from '../../bot/group-handler.js';
 import { isReplyToBot, isAcknowledgment } from '../../bot/reactions.js';
@@ -69,8 +69,8 @@ export async function processWhatsAppRawMessage(sock: WASocket, msg: WAMessage):
   }, {
     ownerId: config.OWNER_JID,
     isGroupEnabled,
-    introductionsChatId: INTRODUCTIONS_JID,
-    eventsChatId: EVENTS_JID,
+    introductionsChatId: getEnabledGroupJidByName('Introductions'),
+    eventsChatId: getEnabledGroupJidByName('Events'),
     handleIntroduction,
     handleEventPassive,
   });

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -45,6 +45,7 @@ function mockHandlerDeps(): HandlerMocks {
   vi.doMock('../src/bot/groups.js', () => ({
     isGroupEnabled,
     getGroupName: vi.fn(() => 'General'),
+    getEnabledGroupJidByName: vi.fn((name: string) => (name === 'Introductions' ? 'intro@g.us' : null)),
   }));
 
   vi.doMock('../src/features/welcome.js', () => ({ buildWelcomeMessage }));


### PR DESCRIPTION
## Objective
Reduce cross-layer coupling by resolving special group JIDs (Introductions/Events) from `config/groups.json` via `src/bot/groups.ts`, instead of importing JID constants from feature modules.

Closes: n/a

## Problem
- A few runtime entrypoints imported `INTRODUCTIONS_JID`/`EVENTS_JID` from feature modules.
- Those constants are derived from `GROUP_IDS` anyway, and pulling them from features makes the runtime depend on feature modules unnecessarily.

## Solution
- Add `getEnabledGroupJidByName(name)` to `src/bot/groups.ts`.
- Use it in:
  - `src/bot/handlers.ts` to preserve the existing "non-notify upserts only for Introductions" behavior.
  - `src/platforms/whatsapp/processor.ts` to populate the core inbound env’s `introductionsChatId`/`eventsChatId`.
- Update `tests/handlers.test.ts` module mock to include the new export.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`

## Risk and Rollback
- Risk level: low
- Primary risk: group name mismatch in config (would result in null JID, matching previous behavior when group disabled/missing).
- Rollback approach: revert this PR

## Operational and Security Checklist
- [x] No secrets or credentials added to tracked files

## Docs and Communication
- [x] `README.md` updated (n/a)
- [x] Relevant `docs/*.md` updated (n/a)
- [x] Release note/customer-facing summary prepared (n/a)

## Reviewer Focus Areas
1. `src/bot/handlers.ts` catch-up gating for non-notify upserts
2. `src/platforms/whatsapp/processor.ts` env wiring