### PR TITLE
refactor: centralize group JID lookups

### DIFF
--- a/src/ai/persona.ts
+++ b/src/ai/persona.ts
@@ -3,8 +3,8 @@ import { resolve } from 'path';
 import { logger } from '../middleware/logger.js';
 import { PROJECT_ROOT, config } from '../utils/config.js';
 import { truncate } from '../utils/formatting.js';
-import { INTRO_SYSTEM_ADDENDUM, INTRODUCTIONS_JID } from '../features/introductions.js';
-import { getGroupPersona } from '../bot/groups.js';
+import { INTRO_SYSTEM_ADDENDUM } from '../features/introductions.js';
+import { getGroupPersona, getEnabledGroupJidByName } from '../bot/groups.js';
 import { formatContext } from '../middleware/context.js';
 import { buildLanguageInstruction } from '../features/language.js';
 import { formatMemoriesForPrompt } from '../utils/db.js';
@@ -35,7 +35,8 @@ export interface MessageContext {
  * Optionally accepts the user's message text for language detection.
  */
 export function buildSystemPrompt(ctx: MessageContext, userMessage?: string): string {
-  const isIntroGroup = INTRODUCTIONS_JID !== null && ctx.groupJid === INTRODUCTIONS_JID;
+  const introductionsChatId = getEnabledGroupJidByName('Introductions');
+  const isIntroGroup = !!introductionsChatId && ctx.groupJid === introductionsChatId;
   const context = formatContext(ctx.groupJid);
   const langInstruction = userMessage ? buildLanguageInstruction(userMessage) : '';
   const memories = formatMemoriesForPrompt();

--- a/src/features/events.ts
+++ b/src/features/events.ts
@@ -1,7 +1,7 @@
 import { logger } from '../middleware/logger.js';
 import { config } from '../utils/config.js';
 import { bold } from '../utils/formatting.js';
-import { GROUP_IDS } from '../bot/groups.js';
+import { getEnabledGroupJidByName } from '../bot/groups.js';
 import { handleWeather } from './weather.js';
 import { handleTransit } from './transit.js';
 import { getAIResponse } from '../ai/router.js';
@@ -21,16 +21,7 @@ const MIN_EVENT_TEXT_LENGTH = 15;
 
 // ── Events group JID ────────────────────────────────────────────────
 
-function getEventsJid(): string | null {
-  for (const [jid, cfg] of Object.entries(GROUP_IDS)) {
-    if (cfg.name === 'Events' && cfg.enabled) {
-      return jid;
-    }
-  }
-  return null;
-}
-
-export const EVENTS_JID = getEventsJid();
+export const EVENTS_JID = getEnabledGroupJidByName('Events');
 
 // ── Event detection patterns ────────────────────────────────────────
 // Adapted from archive/openclaw/hooks/whatsapp-event-enrichment.js

--- a/src/features/introductions.ts
+++ b/src/features/introductions.ts
@@ -7,7 +7,7 @@ import {
 } from '@whiskeysockets/baileys';
 import { logger } from '../middleware/logger.js';
 import { PROJECT_ROOT } from '../utils/config.js';
-import { getGroupName, GROUP_IDS } from '../bot/groups.js';
+import { getGroupName, getEnabledGroupJidByName } from '../bot/groups.js';
 import { getAIResponse } from '../ai/router.js';
 import { getSenderJid } from '../utils/jid.js';
 import { looksLikeIntroduction } from './intro-classifier.js';
@@ -40,17 +40,7 @@ const TRACKER_PATH = resolve(PROJECT_ROOT, 'data', 'intro-tracker.json');
 
 // ── Intro JID lookup ────────────────────────────────────────────────
 
-/** Find the Introductions group JID from config */
-function getIntroductionsJid(): string | null {
-  for (const [jid, cfg] of Object.entries(GROUP_IDS)) {
-    if (cfg.name === 'Introductions' && cfg.enabled) {
-      return jid;
-    }
-  }
-  return null;
-}
-
-export const INTRODUCTIONS_JID = getIntroductionsJid();
+export const INTRODUCTIONS_JID = getEnabledGroupJidByName('Introductions');
 
 // ── Tracker (persisted set of message IDs we've responded to) ───────
 


### PR DESCRIPTION
## Objective
Reduce duplication and cross-module coupling by resolving special group JIDs (Introductions/Events) through the shared `src/bot/groups.ts` helper.

Closes: n/a

## Problem
- `src/features/introductions.ts` and `src/features/events.ts` duplicated JID lookup loops over config.
- `src/ai/persona.ts` depended on `INTRODUCTIONS_JID` exported from the Introductions feature.

## Solution
- Use `getEnabledGroupJidByName()` in:
  - `src/features/introductions.ts` (`INTRODUCTIONS_JID`)
  - `src/features/events.ts` (`EVENTS_JID`)
  - `src/ai/persona.ts` (intro group detection)

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`

## Risk and Rollback
- Risk level: low
- Rollback approach: revert this PR

## Operational and Security Checklist
- [x] No secrets or credentials added to tracked files

## Docs and Communication
- [x] `README.md` updated (n/a)
- [x] Relevant `docs/*.md` updated (n/a)
- [x] Release note/customer-facing summary prepared (n/a)

## Reviewer Focus Areas
1. `src/ai/persona.ts` intro-group detection
2. `src/features/introductions.ts` / `src/features/events.ts` constants