### PR TITLE
refactor: drop handler helper exports

### DIFF
--- a/src/bot/handlers.ts
+++ b/src/bot/handlers.ts
@@ -8,12 +8,6 @@ import { buildWelcomeMessage } from '../features/welcome.js';
 import { recordBotResponse } from '../middleware/stats.js';
 import { setRetryHandler, type RetryEntry } from '../middleware/retry.js';
 import { processWhatsAppRawMessage } from '../platforms/whatsapp/processor.js';
-import {
-  extractWhatsAppText as extractText,
-  extractWhatsAppQuotedText as extractQuotedText,
-  extractWhatsAppMentionedJids as extractMentionedJids,
-} from '../platforms/whatsapp/inbound.js';
-
 import { getResponse } from './response-router.js';
 
 /**
@@ -72,12 +66,6 @@ export function registerHandlers(sock: WASocket): void {
 
   logger.info('Message handlers registered');
 }
-
-// ── Shared helpers (exported for use by owner-commands.ts and group-handler.ts) ──
-
-// These helpers are WhatsApp-specific today, but are implemented outside
-// the handlers module so we can reuse them in a future platform adapter.
-export { extractText, extractQuotedText, extractMentionedJids };
 
 // ── Message routing (private) ───────────────────────────────────────
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -120,7 +120,7 @@ describe('Handlers helper functions', () => {
 
   it('extractText handles all supported message text fields', async () => {
     mockHandlerDeps();
-    const { extractText } = await import('../src/bot/handlers.js');
+    const { extractWhatsAppText: extractText } = await import('../src/platforms/whatsapp/inbound.js');
 
     expect(extractText({ conversation: 'hello' } as never)).toBe('hello');
     expect(extractText({ extendedTextMessage: { text: 'extended' } } as never)).toBe('extended');
@@ -132,7 +132,7 @@ describe('Handlers helper functions', () => {
 
   it('extractQuotedText unwraps quoted text and returns undefined when absent', async () => {
     mockHandlerDeps();
-    const { extractQuotedText } = await import('../src/bot/handlers.js');
+    const { extractWhatsAppQuotedText: extractQuotedText } = await import('../src/platforms/whatsapp/inbound.js');
 
     const content = {
       extendedTextMessage: {
@@ -150,7 +150,7 @@ describe('Handlers helper functions', () => {
 
   it('extractMentionedJids reads mentions from different content types', async () => {
     mockHandlerDeps();
-    const { extractMentionedJids } = await import('../src/bot/handlers.js');
+    const { extractWhatsAppMentionedJids: extractMentionedJids } = await import('../src/platforms/whatsapp/inbound.js');
 
     expect(extractMentionedJids({
       extendedTextMessage: { contextInfo: { mentionedJid: ['a@s.whatsapp.net'] } },


### PR DESCRIPTION
## Objective
Keep WhatsApp inbound parsing helpers in the WhatsApp inbound module, and avoid re-exporting them from `src/bot/handlers.ts`.

Closes: n/a

## Problem
- `src/bot/handlers.ts` re-exported inbound parsing helpers (`extractText`, `extractQuotedText`, `extractMentionedJids`) that are WhatsApp-specific.
- Nothing in runtime used these exports anymore, but tests still imported them from `handlers.ts`.

## Solution
- Remove the re-exports and the unused imports from `src/bot/handlers.ts`.
- Update `tests/handlers.test.ts` to import the helpers directly from `src/platforms/whatsapp/inbound.ts`.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`

## Risk and Rollback
- Risk level: low
- Rollback approach: revert this PR

## Operational and Security Checklist
- [x] No secrets or credentials added to tracked files

## Docs and Communication
- [x] `README.md` updated (n/a)
- [x] Relevant `docs/*.md` updated (n/a)
- [x] Release note/customer-facing summary prepared (n/a)