### PR TITLE
refactor: remove bot handlers module

### DIFF
--- a/src/bot/handlers.ts
+++ b/src/bot/handlers.ts
@@ -1,3 +1,0 @@
-// WhatsApp-specific handler implementation lives in the WhatsApp platform folder.
-// We keep this re-export for backwards compatibility inside the codebase.
-export { registerWhatsAppHandlers as registerHandlers } from '../platforms/whatsapp/handlers.js';

--- a/src/platforms/whatsapp/runtime.ts
+++ b/src/platforms/whatsapp/runtime.ts
@@ -1,7 +1,7 @@
 import type { WASocket } from '@whiskeysockets/baileys';
 import { logger } from '../../middleware/logger.js';
 import { startConnection } from '../../bot/connection.js';
-import { registerHandlers } from '../../bot/handlers.js';
+import { registerWhatsAppHandlers } from './handlers.js';
 import { registerIntroCatchUp } from '../../features/introductions.js';
 import { scheduleDigest } from '../../features/digest.js';
 import type { PlatformRuntime } from '../types.js';
@@ -11,7 +11,7 @@ export function createWhatsAppRuntime(): PlatformRuntime {
     platform: 'whatsapp',
     async start(): Promise<void> {
       await startConnection((sock: WASocket) => {
-        registerHandlers(sock);
+        registerWhatsAppHandlers(sock);
         registerIntroCatchUp(sock);
         scheduleDigest(sock);
         logger.info('🫘 WhatsApp runtime started');

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -180,7 +180,7 @@ describe('registerHandlers wiring and edge branches', () => {
 
   it('registers retry handler and sends retry response through socket', async () => {
     const mocks = mockHandlerDeps();
-    const { registerHandlers } = await import('../src/bot/handlers.js');
+    const { registerWhatsAppHandlers: registerHandlers } = await import('../src/platforms/whatsapp/handlers.js');
 
     const handlers: Record<string, (payload: unknown) => Promise<void>> = {};
     const sock = {
@@ -219,7 +219,7 @@ describe('registerHandlers wiring and edge branches', () => {
 
   it('sends welcome message for enabled groups on participant add', async () => {
     const mocks = mockHandlerDeps();
-    const { registerHandlers } = await import('../src/bot/handlers.js');
+    const { registerWhatsAppHandlers: registerHandlers } = await import('../src/platforms/whatsapp/handlers.js');
 
     const handlers: Record<string, (payload: unknown) => Promise<void>> = {};
     const sock = {
@@ -246,7 +246,7 @@ describe('registerHandlers wiring and edge branches', () => {
 
   it('skips non-notify upserts except for Introductions group catch-up path', async () => {
     const mocks = mockHandlerDeps();
-    const { registerHandlers } = await import('../src/bot/handlers.js');
+    const { registerWhatsAppHandlers: registerHandlers } = await import('../src/platforms/whatsapp/handlers.js');
 
     const handlers: Record<string, (payload: unknown) => Promise<void>> = {};
     const sock = {


### PR DESCRIPTION
## Objective
Remove the now-unneeded `src/bot/handlers.ts` layer and reference the WhatsApp handler wiring directly from the WhatsApp platform.

Closes: n/a

## Problem
- After moving the handler wiring into `src/platforms/whatsapp/handlers.ts`, `src/bot/handlers.ts` became a thin re-export that only added indirection.

## Solution
- Delete `src/bot/handlers.ts`.
- Update:
  - `src/platforms/whatsapp/runtime.ts` to import `registerWhatsAppHandlers` directly.
  - `tests/handlers.test.ts` to import the WhatsApp handler wiring directly.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`