### PR TITLE
refactor: move WhatsApp group handler into platform

### DIFF
--- a/src/platforms/whatsapp/group-handler.ts
+++ b/src/platforms/whatsapp/group-handler.ts
@@ -1,16 +1,16 @@
 import type { WASocket, WAMessage, WAMessageContent } from '@whiskeysockets/baileys';
 
-import { logger } from '../middleware/logger.js';
-import { config } from '../utils/config.js';
-import { requiresMention, isMentioned, stripMention, getGroupName, isFeatureEnabled } from './groups.js';
-import { extractMedia, prepareForVision, type VisionImage } from '../features/media.js';
+import { logger } from '../../middleware/logger.js';
+import { config } from '../../utils/config.js';
+import { requiresMention, isMentioned, stripMention, getGroupName, isFeatureEnabled } from '../../bot/groups.js';
+import { extractMedia, prepareForVision, type VisionImage } from '../../features/media.js';
 import {
   extractWhatsAppMentionedJids as extractMentionedJids,
   extractWhatsAppQuotedText as extractQuotedText,
-} from '../platforms/whatsapp/inbound.js';
-import { processGroupMessage } from '../core/process-group-message.js';
-import { getResponse } from './response-router.js';
-import { createWhatsAppAdapter } from '../platforms/whatsapp/adapter.js';
+} from './inbound.js';
+import { processGroupMessage } from '../../core/process-group-message.js';
+import { getResponse } from '../../bot/response-router.js';
+import { createWhatsAppAdapter } from './adapter.js';
 
 /**
  * Handle a group message that has already passed preprocessing

--- a/src/platforms/whatsapp/processor.ts
+++ b/src/platforms/whatsapp/processor.ts
@@ -8,7 +8,7 @@ import { handleEventPassive } from '../../features/events.js';
 import { config } from '../../utils/config.js';
 import { isGroupEnabled, getEnabledGroupJidByName } from '../../bot/groups.js';
 import { handleOwnerDM } from '../../bot/owner-commands.js';
-import { handleGroupMessage } from '../../bot/group-handler.js';
+import { handleGroupMessage } from './group-handler.js';
 import { isReplyToBot, isAcknowledgment } from '../../bot/reactions.js';
 import { normalizeWhatsAppInboundMessage, type WhatsAppInbound } from './inbound.js';
 import { createWhatsAppAdapter } from './adapter.js';

--- a/tests/core-group-parity.test.ts
+++ b/tests/core-group-parity.test.ts
@@ -113,7 +113,7 @@ describe('Core group processor parity (WhatsApp)', () => {
     const { isFeatureEnabled } = setupMocks();
     isFeatureEnabled.mockImplementation((_jid: string, feature: string) => feature === 'poll');
 
-    const { handleGroupMessage } = await import('../src/bot/group-handler.js');
+    const { handleGroupMessage } = await import('../src/platforms/whatsapp/group-handler.js');
     const { processGroupMessage } = await import('../src/core/process-group-message.js');
 
     const legacyCalls: Array<{ to: string; content: unknown }> = [];
@@ -179,7 +179,7 @@ describe('Core group processor parity (WhatsApp)', () => {
   it('suggest command sends equivalent group response and owner DM', async () => {
     setupMocks();
 
-    const { handleGroupMessage } = await import('../src/bot/group-handler.js');
+    const { handleGroupMessage } = await import('../src/platforms/whatsapp/group-handler.js');
     const { processGroupMessage } = await import('../src/core/process-group-message.js');
 
     const legacyCalls: Array<{ to: string; content: unknown }> = [];

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -94,7 +94,7 @@ function mockHandlerDeps(): HandlerMocks {
   vi.doMock('../src/features/voice.js', () => ({ transcribeAudio: vi.fn(async () => null) }));
   vi.doMock('../src/middleware/health.js', () => ({ markMessageReceived }));
   vi.doMock('../src/bot/owner-commands.js', () => ({ handleOwnerDM }));
-  vi.doMock('../src/bot/group-handler.js', () => ({ handleGroupMessage: vi.fn(async () => undefined) }));
+  vi.doMock('../src/platforms/whatsapp/group-handler.js', () => ({ handleGroupMessage: vi.fn(async () => undefined) }));
   vi.doMock('../src/bot/reactions.js', () => ({
     isReplyToBot: vi.fn(() => false),
     isAcknowledgment: vi.fn(() => false),


### PR DESCRIPTION
## Objective
Keep WhatsApp-specific group handling (mentions + media extraction) under the WhatsApp platform folder.

Closes: n/a

## Problem
- `src/bot/group-handler.ts` was WhatsApp-specific but lived in the bot layer.

## Solution
- Move implementation to `src/platforms/whatsapp/group-handler.ts`.
- Update WhatsApp processor wiring to import it locally.
- Update tests that referenced the old module path.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`