### PR TITLE
refactor: move WhatsApp owner commands into platform

### DIFF
--- a/src/platforms/whatsapp/owner-commands.ts
+++ b/src/platforms/whatsapp/owner-commands.ts
@@ -1,16 +1,17 @@
 import type { WASocket } from '@whiskeysockets/baileys';
-import { logger } from '../middleware/logger.js';
-import { config } from '../utils/config.js';
-import { getHelpMessage, getOwnerHelpMessage } from '../features/help.js';
-import { triggerIntroCatchUp } from '../features/introductions.js';
-import { previewDigest } from '../features/digest.js';
-import { formatStrikesReport } from '../features/moderation.js';
-import { handleFeedbackOwner, createGitHubIssueFromFeedback } from '../features/feedback.js';
-import { handleRelease } from '../features/release.js';
-import { handleMemory } from '../features/memory.js';
-import { recordOwnerDM } from '../middleware/stats.js';
-import { GROUP_IDS } from './groups.js';
-import { getResponse } from './response-router.js';
+
+import { logger } from '../../middleware/logger.js';
+import { config } from '../../utils/config.js';
+import { getHelpMessage, getOwnerHelpMessage } from '../../features/help.js';
+import { triggerIntroCatchUp } from '../../features/introductions.js';
+import { previewDigest } from '../../features/digest.js';
+import { formatStrikesReport } from '../../features/moderation.js';
+import { handleFeedbackOwner, createGitHubIssueFromFeedback } from '../../features/feedback.js';
+import { handleRelease } from '../../features/release.js';
+import { handleMemory } from '../../features/memory.js';
+import { recordOwnerDM } from '../../middleware/stats.js';
+import { GROUP_IDS } from '../../bot/groups.js';
+import { getResponse } from '../../bot/response-router.js';
 
 function buildSupportMessage(): string {
   const lines: string[] = [

--- a/src/platforms/whatsapp/processor.ts
+++ b/src/platforms/whatsapp/processor.ts
@@ -7,7 +7,7 @@ import { handleIntroduction } from '../../features/introductions.js';
 import { handleEventPassive } from '../../features/events.js';
 import { config } from '../../utils/config.js';
 import { isGroupEnabled, getEnabledGroupJidByName } from '../../bot/groups.js';
-import { handleOwnerDM } from '../../bot/owner-commands.js';
+import { handleOwnerDM } from './owner-commands.js';
 import { handleGroupMessage } from './group-handler.js';
 import { isReplyToBot, isAcknowledgment } from '../../bot/reactions.js';
 import { normalizeWhatsAppInboundMessage, type WhatsAppInbound } from './inbound.js';

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -93,7 +93,7 @@ function mockHandlerDeps(): HandlerMocks {
 
   vi.doMock('../src/features/voice.js', () => ({ transcribeAudio: vi.fn(async () => null) }));
   vi.doMock('../src/middleware/health.js', () => ({ markMessageReceived }));
-  vi.doMock('../src/bot/owner-commands.js', () => ({ handleOwnerDM }));
+  vi.doMock('../src/platforms/whatsapp/owner-commands.js', () => ({ handleOwnerDM }));
   vi.doMock('../src/platforms/whatsapp/group-handler.js', () => ({ handleGroupMessage: vi.fn(async () => undefined) }));
   vi.doMock('../src/bot/reactions.js', () => ({
     isReplyToBot: vi.fn(() => false),

--- a/tests/owner-commands.test.ts
+++ b/tests/owner-commands.test.ts
@@ -52,7 +52,7 @@ describe('owner support commands', () => {
 
   it('returns false for non-owner sender', async () => {
     mockOwnerDeps();
-    const { handleOwnerDM } = await import('../src/bot/owner-commands.js');
+    const { handleOwnerDM } = await import('../src/platforms/whatsapp/owner-commands.js');
     const sock = { sendMessage: vi.fn(async () => undefined) };
 
     const handled = await handleOwnerDM(sock as never, 'owner@s.whatsapp.net', 'user@s.whatsapp.net', '!support');
@@ -62,7 +62,7 @@ describe('owner support commands', () => {
 
   it('sends support links on !support', async () => {
     mockOwnerDeps();
-    const { handleOwnerDM } = await import('../src/bot/owner-commands.js');
+    const { handleOwnerDM } = await import('../src/platforms/whatsapp/owner-commands.js');
     const sock = { sendMessage: vi.fn(async () => undefined) };
 
     const handled = await handleOwnerDM(sock as never, 'owner@s.whatsapp.net', 'owner@s.whatsapp.net', '!support');
@@ -78,7 +78,7 @@ describe('owner support commands', () => {
 
   it('broadcasts support links to all enabled groups', async () => {
     mockOwnerDeps();
-    const { handleOwnerDM } = await import('../src/bot/owner-commands.js');
+    const { handleOwnerDM } = await import('../src/platforms/whatsapp/owner-commands.js');
     const sock = { sendMessage: vi.fn(async () => undefined) };
 
     const handled = await handleOwnerDM(sock as never, 'owner@s.whatsapp.net', 'owner@s.whatsapp.net', '!support broadcast');
@@ -93,7 +93,7 @@ describe('owner support commands', () => {
 
   it('creates GitHub issue from accepted feedback via owner command', async () => {
     mockOwnerDeps();
-    const { handleOwnerDM } = await import('../src/bot/owner-commands.js');
+    const { handleOwnerDM } = await import('../src/platforms/whatsapp/owner-commands.js');
     const sock = { sendMessage: vi.fn(async () => undefined) };
 
     const handled = await handleOwnerDM(


### PR DESCRIPTION
## Objective
Keep WhatsApp-specific owner DM command routing under the WhatsApp platform folder.

Closes: n/a

## Problem
- `src/bot/owner-commands.ts` was WhatsApp/Baileys-specific (`WASocket`) but lived in the bot layer.

## Solution
- Move implementation to `src/platforms/whatsapp/owner-commands.ts`.
- Update WhatsApp processor wiring and tests to reference the new module path.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`