### PR TITLE
refactor: move digest scheduling into WhatsApp platform

### DIFF
--- a/src/features/digest.ts
+++ b/src/features/digest.ts
@@ -5,60 +5,18 @@
  * (no cron dependency). Reschedules itself after each run.
  */
 
-import type { WASocket } from '@whiskeysockets/baileys';
 import { logger } from '../middleware/logger.js';
-import { config } from '../utils/config.js';
-import { getCurrentStats, snapshotAndReset, type DailyStats } from '../middleware/stats.js';
+import { getCurrentStats, type DailyStats } from '../middleware/stats.js';
 import { getGroupName } from '../bot/groups.js';
 import { saveDailyStats } from '../utils/db.js';
 
-const DIGEST_HOUR = 21; // 9 PM local time
-
-/**
- * Schedule the daily digest. Call once at startup.
- * Automatically reschedules after each digest send.
- */
-export function scheduleDigest(sock: WASocket): void {
-  const msUntilDigest = msUntilHour(DIGEST_HOUR);
-  const hoursUntil = Math.round(msUntilDigest / 1000 / 60 / 60 * 10) / 10;
-
-  logger.info({ nextDigestIn: `${hoursUntil}h`, targetHour: DIGEST_HOUR }, 'Daily digest scheduled');
-
-  setTimeout(async () => {
-    try {
-      await sendDigest(sock);
-    } catch (err) {
-      logger.error({ err, targetHour: DIGEST_HOUR }, 'Failed to send daily digest');
-    }
-    // Reschedule for tomorrow
-    scheduleDigest(sock);
-  }, msUntilDigest);
-}
-
-/**
- * Send the daily digest to the owner's DM.
- * Also available as `!digest` owner command.
- */
-async function sendDigest(sock: WASocket): Promise<string> {
-  const stats = snapshotAndReset();
-  const text = formatDigest(stats);
-
-  // Archive to SQLite
+export function archiveDailyDigest(stats: DailyStats): void {
   try {
     const archiveData = serializeStats(stats);
     saveDailyStats(stats.date, archiveData);
   } catch (err) {
     logger.error({ err, date: stats.date }, 'Failed to archive daily stats');
   }
-
-  try {
-    await sock.sendMessage(config.OWNER_JID, { text });
-    logger.info({ date: stats.date }, 'Daily digest sent');
-  } catch (err) {
-    logger.error({ err, ownerJid: config.OWNER_JID, date: stats.date }, 'Failed to send digest to owner DM');
-  }
-
-  return text;
 }
 
 /**
@@ -69,7 +27,7 @@ export function previewDigest(): string {
   return formatDigest(getCurrentStats());
 }
 
-function formatDigest(stats: DailyStats): string {
+export function formatDigest(stats: DailyStats): string {
   const lines: string[] = [
     `🫘 *Daily Digest — ${stats.date}*`,
     '',
@@ -163,16 +121,3 @@ function serializeStats(stats: DailyStats): string {
   return JSON.stringify({ date: stats.date, groups, ownerDMs: stats.ownerDMs });
 }
 
-/** Calculate milliseconds from now until the next occurrence of a given hour */
-function msUntilHour(hour: number): number {
-  const now = new Date();
-  const target = new Date(now);
-  target.setHours(hour, 0, 0, 0);
-
-  // If we've already passed this hour today, schedule for tomorrow
-  if (now >= target) {
-    target.setDate(target.getDate() + 1);
-  }
-
-  return target.getTime() - now.getTime();
-}

--- a/src/platforms/whatsapp/digest.ts
+++ b/src/platforms/whatsapp/digest.ts
@@ -1,0 +1,61 @@
+import type { WASocket } from '@whiskeysockets/baileys';
+
+import { logger } from '../../middleware/logger.js';
+import { config } from '../../utils/config.js';
+import { snapshotAndReset } from '../../middleware/stats.js';
+import { archiveDailyDigest, formatDigest } from '../../features/digest.js';
+
+const DIGEST_HOUR = 21; // 9 PM local time
+
+/**
+ * Schedule the daily digest. Call once at startup.
+ * Automatically reschedules after each digest send.
+ */
+export function scheduleDigest(sock: WASocket): void {
+  const msUntilDigest = msUntilHour(DIGEST_HOUR);
+  const hoursUntil = Math.round((msUntilDigest / 1000 / 60 / 60) * 10) / 10;
+
+  logger.info({ nextDigestIn: `${hoursUntil}h`, targetHour: DIGEST_HOUR }, 'Daily digest scheduled');
+
+  setTimeout(async () => {
+    try {
+      await sendDigest(sock);
+    } catch (err) {
+      logger.error({ err, targetHour: DIGEST_HOUR }, 'Failed to send daily digest');
+    }
+
+    // Reschedule for tomorrow
+    scheduleDigest(sock);
+  }, msUntilDigest);
+}
+
+async function sendDigest(sock: WASocket): Promise<string> {
+  const stats = snapshotAndReset();
+  const text = formatDigest(stats);
+
+  // Archive to SQLite
+  archiveDailyDigest(stats);
+
+  try {
+    await sock.sendMessage(config.OWNER_JID, { text });
+    logger.info({ date: stats.date }, 'Daily digest sent');
+  } catch (err) {
+    logger.error({ err, ownerId: config.OWNER_JID, date: stats.date }, 'Failed to send digest to owner DM');
+  }
+
+  return text;
+}
+
+/** Calculate milliseconds from now until the next occurrence of a given hour */
+function msUntilHour(hour: number): number {
+  const now = new Date();
+  const target = new Date(now);
+  target.setHours(hour, 0, 0, 0);
+
+  // If we've already passed this hour today, schedule for tomorrow
+  if (now >= target) {
+    target.setDate(target.getDate() + 1);
+  }
+
+  return target.getTime() - now.getTime();
+}

--- a/src/platforms/whatsapp/runtime.ts
+++ b/src/platforms/whatsapp/runtime.ts
@@ -3,7 +3,7 @@ import { logger } from '../../middleware/logger.js';
 import { startConnection } from './connection.js';
 import { registerWhatsAppHandlers } from './handlers.js';
 import { registerIntroCatchUp } from './introductions-catchup.js';
-import { scheduleDigest } from '../../features/digest.js';
+import { scheduleDigest } from './digest.js';
 import type { PlatformRuntime } from '../types.js';
 
 export function createWhatsAppRuntime(): PlatformRuntime {


### PR DESCRIPTION
## Objective
Keep sending/scheduling of the daily digest under the WhatsApp platform folder, while leaving digest formatting + archiving in the feature layer.

Closes: n/a

## Problem
- `src/features/digest.ts` depended on Baileys `WASocket` and `config.OWNER_JID` to send DMs.

## Solution
- Move scheduling + send to `src/platforms/whatsapp/digest.ts` (`scheduleDigest`).
- Keep feature module platform-agnostic:
  - `src/features/digest.ts` exports `formatDigest()` and `archiveDailyDigest()`
  - `previewDigest()` continues to work for the owner command.
- Update `src/platforms/whatsapp/runtime.ts` to schedule from the platform module.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`