### PR TITLE
refactor: make release helper platform-agnostic

### DIFF
--- a/src/features/release.ts
+++ b/src/features/release.ts
@@ -9,7 +9,6 @@
  * an official update from the bot operator.
  */
 
-import type { WASocket } from '@whiskeysockets/baileys';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { logger } from '../middleware/logger.js';
@@ -93,7 +92,7 @@ function getChangelogSnippet(maxLines: number = 12): string {
  */
 export async function handleRelease(
   args: string,
-  sock: WASocket,
+  sendText: (chatId: string, text: string) => Promise<void>,
 ): Promise<string> {
   if (!args.trim()) {
     return [
@@ -149,7 +148,7 @@ export async function handleRelease(
 
   for (const jid of targetJids) {
     try {
-      await sock.sendMessage(jid, { text: formatted });
+      await sendText(jid, formatted);
       sent++;
     } catch (err) {
       logger.error({ err, jid }, 'Failed to send release notes');

--- a/src/platforms/whatsapp/owner-commands.ts
+++ b/src/platforms/whatsapp/owner-commands.ts
@@ -129,7 +129,9 @@ export async function handleOwnerDM(
   // !release [args]
   if (trimmedLower.startsWith('!release')) {
     const args = text.trim().slice('!release'.length).trim();
-    const result = await handleRelease(args, sock);
+    const result = await handleRelease(args, async (jid, t) => {
+      await sock.sendMessage(jid, { text: t });
+    });
     await sock.sendMessage(remoteJid, { text: result });
     return true;
   }

--- a/tests/phase6.test.ts
+++ b/tests/phase6.test.ts
@@ -343,7 +343,7 @@ describe('Feature flags — per-group persona', async () => {
 
 describe('Release — command parsing', async () => {
   // We can't test actual sending without a socket, but we can test the help output
-  // handleRelease requires a WASocket which we can't easily mock here.
+  // handleRelease requires a sendText function which we don't exercise here.
   // Just verify the module imports without error.
   it('module loads without error', async () => {
     const mod = await import('../src/features/release.js');

--- a/tests/release.test.ts
+++ b/tests/release.test.ts
@@ -26,35 +26,35 @@ describe('release notes helper', () => {
   it('shows changelog usage in help text', async () => {
     mockReleaseDeps();
     const { handleRelease } = await import('../src/features/release.js');
-    const sock = { sendMessage: vi.fn(async () => undefined) };
+    const sendText = vi.fn(async () => undefined);
 
-    const result = await handleRelease('', sock as never);
+    const result = await handleRelease('', sendText);
     expect(result).toContain('!release changelog');
   });
 
   it('broadcasts changelog snippet to all enabled groups', async () => {
     mockReleaseDeps();
     const { handleRelease } = await import('../src/features/release.js');
-    const sock = { sendMessage: vi.fn(async () => undefined) };
+    const sendText = vi.fn(async () => undefined);
 
-    const result = await handleRelease('changelog', sock as never);
+    const result = await handleRelease('changelog', sendText);
     expect(result).toContain('Release notes sent to 2 groups');
 
-    const calls = sock.sendMessage.mock.calls as unknown as Array<[string, { text?: string }]>;
+    const calls = sendText.mock.calls as unknown as Array<[string, string]>;
     expect(calls).toHaveLength(2);
-    expect(calls[0]?.[1]?.text).toContain('What\'s New with Garbanzo');
-    expect(calls[0]?.[1]?.text).toContain('Changelog');
+    expect(calls[0]?.[1]).toContain('What\'s New with Garbanzo');
+    expect(calls[0]?.[1]).toContain('Changelog');
   });
 
   it('sends changelog snippet to one target group', async () => {
     mockReleaseDeps();
     const { handleRelease } = await import('../src/features/release.js');
-    const sock = { sendMessage: vi.fn(async () => undefined) };
+    const sendText = vi.fn(async () => undefined);
 
-    const result = await handleRelease('general changelog', sock as never);
+    const result = await handleRelease('general changelog', sendText);
     expect(result).toContain('Release notes sent to 1 group');
 
-    const calls = sock.sendMessage.mock.calls as unknown as Array<[string, { text?: string }]>;
+    const calls = sendText.mock.calls as unknown as Array<[string, string]>;
     expect(calls).toHaveLength(1);
     expect(calls[0]?.[0]).toBe('general@g.us');
   });


### PR DESCRIPTION
## Objective
Remove the Baileys `WASocket` dependency from the release notes helper by injecting a `sendText` function.

Closes: n/a

## Problem
- `src/features/release.ts` imported `WASocket` and sent messages via `sock.sendMessage`, which made the feature module WhatsApp-specific.

## Solution
- Change `handleRelease` signature to accept `sendText(chatId, text)`.
- Wire WhatsApp owner commands to pass `sock.sendMessage` via a small adapter function.
- Update tests to use the new signature.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`