### PR TITLE
refactor: move response routing into core

### DIFF
--- a/src/core/process-group-message.ts
+++ b/src/core/process-group-message.ts
@@ -25,7 +25,12 @@ export interface ProcessGroupMessageParams {
   query: string;
 
   isFeatureEnabled: (chatId: string, feature: string) => boolean;
-  getResponse: (query: string, ctx: MessageContext, visionImages?: VisionImage[]) => Promise<string | null>;
+  getResponse: (
+    query: string,
+    ctx: MessageContext,
+    isFeatureEnabled: (chatId: string, feature: string) => boolean,
+    visionImages?: VisionImage[],
+  ) => Promise<string | null>;
 
   quotedText?: string;
   messageId?: string;
@@ -132,12 +137,17 @@ export async function processGroupMessage(params: ProcessGroupMessageParams): Pr
 
   const enrichedQuery = urlContext ? query + urlContext : query;
 
-  const response = await getResponse(enrichedQuery, {
-    groupName,
-    groupJid: chatId,
-    senderJid: senderId,
-    quotedText,
-  }, visionImages);
+  const response = await getResponse(
+    enrichedQuery,
+    {
+      groupName,
+      groupJid: chatId,
+      senderJid: senderId,
+      quotedText,
+    },
+    isFeatureEnabled,
+    visionImages,
+  );
 
   if (response) {
     // If AI returned the error fallback, queue for retry instead of sending error

--- a/src/platforms/whatsapp/group-handler.ts
+++ b/src/platforms/whatsapp/group-handler.ts
@@ -10,7 +10,7 @@ import {
   extractWhatsAppQuotedText as extractQuotedText,
 } from './inbound.js';
 import { processGroupMessage } from '../../core/process-group-message.js';
-import { getResponse } from '../../bot/response-router.js';
+import { getResponse } from '../../core/response-router.js';
 import { createWhatsAppAdapter } from './adapter.js';
 
 /**

--- a/src/platforms/whatsapp/handlers.ts
+++ b/src/platforms/whatsapp/handlers.ts
@@ -1,11 +1,11 @@
 import type { WASocket, WAMessage } from '@whiskeysockets/baileys';
 
 import { logger } from '../../middleware/logger.js';
-import { isGroupEnabled, getGroupName, getEnabledGroupJidByName } from '../../bot/groups.js';
+import { isGroupEnabled, getGroupName, getEnabledGroupJidByName, isFeatureEnabled } from '../../bot/groups.js';
 import { buildWelcomeMessage } from '../../features/welcome.js';
 import { recordBotResponse } from '../../middleware/stats.js';
 import { setRetryHandler, type RetryEntry } from '../../middleware/retry.js';
-import { getResponse } from '../../bot/response-router.js';
+import { getResponse } from '../../core/response-router.js';
 
 import { processWhatsAppRawMessage } from './processor.js';
 
@@ -20,7 +20,7 @@ export function registerWhatsAppHandlers(sock: WASocket): void {
       groupName,
       groupJid: entry.groupJid,
       senderJid: entry.senderJid,
-    });
+    }, isFeatureEnabled);
     if (response) {
       await sock.sendMessage(entry.groupJid, { text: response });
       recordBotResponse(entry.groupJid);

--- a/src/platforms/whatsapp/owner-commands.ts
+++ b/src/platforms/whatsapp/owner-commands.ts
@@ -10,8 +10,8 @@ import { handleFeedbackOwner, createGitHubIssueFromFeedback } from '../../featur
 import { handleRelease } from '../../features/release.js';
 import { handleMemory } from '../../features/memory.js';
 import { recordOwnerDM } from '../../middleware/stats.js';
-import { GROUP_IDS } from '../../bot/groups.js';
-import { getResponse } from '../../bot/response-router.js';
+import { GROUP_IDS, isFeatureEnabled } from '../../bot/groups.js';
+import { getResponse } from '../../core/response-router.js';
 
 function buildSupportMessage(): string {
   const lines: string[] = [
@@ -171,7 +171,7 @@ export async function handleOwnerDM(
     groupName: 'DM',
     groupJid: remoteJid,
     senderJid,
-  });
+  }, isFeatureEnabled);
 
   if (response) {
     await sock.sendMessage(remoteJid, { text: response });

--- a/tests/core-group-parity.test.ts
+++ b/tests/core-group-parity.test.ts
@@ -90,7 +90,7 @@ function setupMocks() {
     prepareForVision: vi.fn(async () => []),
   }));
 
-  vi.doMock('../src/bot/response-router.js', () => ({
+  vi.doMock('../src/core/response-router.js', () => ({
     getResponse: vi.fn(async () => 'ai response'),
   }));
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -44,6 +44,7 @@ function mockHandlerDeps(): HandlerMocks {
 
   vi.doMock('../src/bot/groups.js', () => ({
     isGroupEnabled,
+    isFeatureEnabled: vi.fn(() => true),
     getGroupName: vi.fn(() => 'General'),
     getEnabledGroupJidByName: vi.fn((name: string) => (name === 'Introductions' ? 'intro@g.us' : null)),
   }));
@@ -100,7 +101,7 @@ function mockHandlerDeps(): HandlerMocks {
     isReplyToBot: vi.fn(() => false),
     isAcknowledgment: vi.fn(() => false),
   }));
-  vi.doMock('../src/bot/response-router.js', () => ({ getResponse }));
+  vi.doMock('../src/core/response-router.js', () => ({ getResponse }));
 
   return {
     setRetryHandler,

--- a/tests/owner-commands.test.ts
+++ b/tests/owner-commands.test.ts
@@ -40,7 +40,7 @@ describe('owner support commands', () => {
     vi.doMock('../src/features/release.js', () => ({ handleRelease: vi.fn(async () => 'release') }));
     vi.doMock('../src/features/memory.js', () => ({ handleMemory: vi.fn(() => 'memory') }));
     vi.doMock('../src/middleware/stats.js', () => ({ recordOwnerDM: vi.fn() }));
-    vi.doMock('../src/bot/response-router.js', () => ({ getResponse: vi.fn(async () => 'ai') }));
+    vi.doMock('../src/core/response-router.js', () => ({ getResponse: vi.fn(async () => 'ai') }));
     vi.doMock('../src/bot/groups.js', () => ({
       GROUP_IDS: {
         'g1@g.us': { name: 'General', enabled: true },


### PR DESCRIPTION
## Objective
Continue the platform/core seam by moving the feature/AI response router out of `src/bot/` into `src/core/`.

Closes: n/a

## Problem
- `src/bot/response-router.ts` is not WhatsApp-specific and is already used by core/platform code.
- It also implicitly depended on `src/bot/groups.ts` for feature gating.

## Solution
- Move router to `src/core/response-router.ts`.
- Inject `isFeatureEnabled(chatId, feature)` into `getResponse(...)` so core does not import bot group config.
- Update WhatsApp callsites and tests/mocks.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`