### PR TITLE
refactor: move group config into core

### DIFF
--- a/src/ai/persona.ts
+++ b/src/ai/persona.ts
@@ -4,7 +4,7 @@ import { logger } from '../middleware/logger.js';
 import { PROJECT_ROOT, config } from '../utils/config.js';
 import { truncate } from '../utils/formatting.js';
 import { INTRO_SYSTEM_ADDENDUM } from '../features/introductions.js';
-import { getGroupPersona, getEnabledGroupJidByName } from '../bot/groups.js';
+import { getGroupPersona, getEnabledGroupJidByName } from '../core/groups-config.js';
 import { formatContext } from '../middleware/context.js';
 import { buildLanguageInstruction } from '../features/language.js';
 import { formatMemoriesForPrompt } from '../utils/db.js';

--- a/src/core/groups-config.ts
+++ b/src/core/groups-config.ts
@@ -1,6 +1,7 @@
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { z } from 'zod';
+
 import { PROJECT_ROOT } from '../utils/config.js';
 
 // ── Zod schema for config/groups.json ───────────────────────────────
@@ -79,60 +80,4 @@ export function isFeatureEnabled(jid: string, feature: string): boolean {
   if (!group) return true; // Unknown group — allow (DMs, etc.)
   if (!group.enabledFeatures || group.enabledFeatures.length === 0) return true;
   return group.enabledFeatures.includes(feature);
-}
-
-/** Extract the bare identifier (without device suffix or domain) from a JID or LID */
-function bareId(jid: string): string {
-  return jid.split('@')[0].split(':')[0];
-}
-
-/**
- * Check if the bot is mentioned — either via WhatsApp's native JID-based
- * mention system (contextInfo.mentionedJid) or via text pattern fallback.
- *
- * WhatsApp is migrating to LIDs (Linked IDs) — mentions may arrive as
- * either `phone@s.whatsapp.net` or `lid@lid`. We check both.
- */
-export function isMentioned(
-  text: string,
-  mentionedJids?: string[],
-  botJid?: string,
-  botLid?: string,
-): boolean {
-  // Primary: check WhatsApp's native mention (JID or LID based)
-  if (mentionedJids?.length) {
-    const botIds = [botJid, botLid]
-      .filter((id): id is string => typeof id === 'string' && id.length > 0)
-      .map((id) => bareId(id));
-    if (mentionedJids.some((jid) => botIds.includes(bareId(jid)))) {
-      return true;
-    }
-  }
-
-  // Fallback: text pattern matching (for users who type "@garbanzo" manually)
-  const lower = text.toLowerCase();
-  return MENTION_PATTERNS.some((pattern) => lower.includes(pattern.toLowerCase()));
-}
-
-/**
- * Strip mention artifacts from the message text.
- * Handles native @mentions (which appear as @phonenumber or @lid) and
- * text-based patterns like "@garbanzo".
- */
-export function stripMention(text: string, botJid?: string, botLid?: string): string {
-  let result = text;
-
-  // Strip native WhatsApp mention formats (@phonenumber or @lid)
-  for (const id of [botJid, botLid].filter((v): v is string => typeof v === 'string' && v.length > 0)) {
-    const num = bareId(id);
-    const idRegex = new RegExp(`@${num}\\b`, 'g');
-    result = result.replace(idRegex, '').trim();
-  }
-
-  // Strip text-based patterns
-  for (const pattern of MENTION_PATTERNS) {
-    const regex = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
-    result = result.replace(regex, '').trim();
-  }
-  return result;
 }

--- a/src/features/digest.ts
+++ b/src/features/digest.ts
@@ -7,7 +7,7 @@
 
 import { logger } from '../middleware/logger.js';
 import { getCurrentStats, type DailyStats } from '../middleware/stats.js';
-import { getGroupName } from '../bot/groups.js';
+import { getGroupName } from '../core/groups-config.js';
 import { saveDailyStats } from '../utils/db.js';
 
 export function archiveDailyDigest(stats: DailyStats): void {

--- a/src/features/events.ts
+++ b/src/features/events.ts
@@ -1,7 +1,7 @@
 import { logger } from '../middleware/logger.js';
 import { config } from '../utils/config.js';
 import { bold } from '../utils/formatting.js';
-import { getEnabledGroupJidByName } from '../bot/groups.js';
+import { getEnabledGroupJidByName } from '../core/groups-config.js';
 import { handleWeather } from './weather.js';
 import { handleTransit } from './transit.js';
 import { getAIResponse } from '../ai/router.js';

--- a/src/features/feedback.ts
+++ b/src/features/feedback.ts
@@ -1,6 +1,6 @@
 import { bold } from '../utils/formatting.js';
 import { logger } from '../middleware/logger.js';
-import { getGroupName } from '../bot/groups.js';
+import { getGroupName } from '../core/groups-config.js';
 import { config } from '../utils/config.js';
 import {
   submitFeedback,

--- a/src/features/introductions.ts
+++ b/src/features/introductions.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
 import { logger } from '../middleware/logger.js';
 import { PROJECT_ROOT } from '../utils/config.js';
-import { getGroupName, getEnabledGroupJidByName } from '../bot/groups.js';
+import { getGroupName, getEnabledGroupJidByName } from '../core/groups-config.js';
 import { getAIResponse } from '../ai/router.js';
 import { looksLikeIntroduction } from './intro-classifier.js';
 

--- a/src/features/moderation.ts
+++ b/src/features/moderation.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { getGroupName } from '../bot/groups.js';
+import { getGroupName } from '../core/groups-config.js';
 import { bold } from '../utils/formatting.js';
 import { phoneFromJid } from '../utils/jid.js';
 import { config } from '../utils/config.js';

--- a/src/features/profiles.ts
+++ b/src/features/profiles.ts
@@ -22,7 +22,7 @@ import {
   deleteProfileData,
   type MemberProfile,
 } from '../utils/db.js';
-import { getGroupName } from '../bot/groups.js';
+import { getGroupName } from '../core/groups-config.js';
 
 /**
  * Handle !profile commands. Returns a response string.

--- a/src/features/recommendations.ts
+++ b/src/features/recommendations.ts
@@ -16,7 +16,7 @@
 
 import { logger } from '../middleware/logger.js';
 import { getProfile, getOptedInProfiles, type MemberProfile } from '../utils/db.js';
-import { getGroupName } from '../bot/groups.js';
+import { getGroupName } from '../core/groups-config.js';
 import { getAIResponse } from '../ai/router.js';
 
 /**

--- a/src/features/release.ts
+++ b/src/features/release.ts
@@ -12,7 +12,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { logger } from '../middleware/logger.js';
-import { GROUP_IDS } from '../bot/groups.js';
+import { GROUP_IDS } from '../core/groups-config.js';
 import { PROJECT_ROOT } from '../utils/config.js';
 
 let cachedVersion: string | null = null;

--- a/src/features/summary.ts
+++ b/src/features/summary.ts
@@ -14,7 +14,7 @@
 import { logger } from '../middleware/logger.js';
 import { getMessages, type DbMessage } from '../utils/db.js';
 import { getAIResponse } from '../ai/router.js';
-import { getGroupName } from '../bot/groups.js';
+import { getGroupName } from '../core/groups-config.js';
 
 const DEFAULT_MESSAGE_COUNT = 50;
 const MAX_MESSAGE_COUNT = 200;

--- a/src/features/welcome.ts
+++ b/src/features/welcome.ts
@@ -1,5 +1,5 @@
 import { logger } from '../middleware/logger.js';
-import { getGroupName } from '../bot/groups.js';
+import { getGroupName } from '../core/groups-config.js';
 import { bold } from '../utils/formatting.js';
 
 /**

--- a/src/platforms/whatsapp/group-handler.ts
+++ b/src/platforms/whatsapp/group-handler.ts
@@ -2,7 +2,8 @@ import type { WASocket, WAMessage, WAMessageContent } from '@whiskeysockets/bail
 
 import { logger } from '../../middleware/logger.js';
 import { config } from '../../utils/config.js';
-import { requiresMention, isMentioned, stripMention, getGroupName, isFeatureEnabled } from '../../bot/groups.js';
+import { requiresMention, getGroupName, isFeatureEnabled } from '../../core/groups-config.js';
+import { isMentioned, stripMention } from './mentions.js';
 import { prepareForVision, type VisionImage } from '../../core/vision.js';
 import { extractMedia } from './media.js';
 import {

--- a/src/platforms/whatsapp/handlers.ts
+++ b/src/platforms/whatsapp/handlers.ts
@@ -1,7 +1,7 @@
 import type { WASocket, WAMessage } from '@whiskeysockets/baileys';
 
 import { logger } from '../../middleware/logger.js';
-import { isGroupEnabled, getGroupName, getEnabledGroupJidByName, isFeatureEnabled } from '../../bot/groups.js';
+import { isGroupEnabled, getGroupName, getEnabledGroupJidByName, isFeatureEnabled } from '../../core/groups-config.js';
 import { buildWelcomeMessage } from '../../features/welcome.js';
 import { recordBotResponse } from '../../middleware/stats.js';
 import { setRetryHandler, type RetryEntry } from '../../middleware/retry.js';

--- a/src/platforms/whatsapp/mentions.ts
+++ b/src/platforms/whatsapp/mentions.ts
@@ -1,0 +1,58 @@
+import { MENTION_PATTERNS } from '../../core/groups-config.js';
+
+/** Extract the bare identifier (without device suffix or domain) from a JID or LID */
+function bareId(jid: string): string {
+  return jid.split('@')[0].split(':')[0];
+}
+
+/**
+ * Check if the bot is mentioned — either via WhatsApp's native JID-based
+ * mention system (contextInfo.mentionedJid) or via text pattern fallback.
+ *
+ * WhatsApp is migrating to LIDs (Linked IDs) — mentions may arrive as
+ * either `phone@s.whatsapp.net` or `lid@lid`. We check both.
+ */
+export function isMentioned(
+  text: string,
+  mentionedJids: string[] | undefined,
+  botJid: string | undefined,
+  botLid: string | undefined,
+): boolean {
+  // Primary: check WhatsApp's native mention (JID or LID based)
+  if (mentionedJids?.length) {
+    const botIds = [botJid, botLid]
+      .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      .map((id) => bareId(id));
+    if (mentionedJids.some((jid) => botIds.includes(bareId(jid)))) {
+      return true;
+    }
+  }
+
+  // Fallback: text pattern matching (for users who type "@garbanzo" manually)
+  const lower = text.toLowerCase();
+  return MENTION_PATTERNS.some((pattern) => lower.includes(pattern.toLowerCase()));
+}
+
+/**
+ * Strip mention artifacts from the message text.
+ * Handles native @mentions (which appear as @phonenumber or @lid) and
+ * text-based patterns like "@garbanzo".
+ */
+export function stripMention(text: string, botJid?: string, botLid?: string): string {
+  let result = text;
+
+  // Strip native WhatsApp mention formats (@phonenumber or @lid)
+  for (const id of [botJid, botLid].filter((v): v is string => typeof v === 'string' && v.length > 0)) {
+    const num = bareId(id);
+    const idRegex = new RegExp(`@${num}\\b`, 'g');
+    result = result.replace(idRegex, '').trim();
+  }
+
+  // Strip text-based patterns
+  for (const pattern of MENTION_PATTERNS) {
+    const regex = new RegExp(pattern.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&'), 'gi');
+    result = result.replace(regex, '').trim();
+  }
+
+  return result;
+}

--- a/src/platforms/whatsapp/owner-commands.ts
+++ b/src/platforms/whatsapp/owner-commands.ts
@@ -10,7 +10,7 @@ import { handleFeedbackOwner, createGitHubIssueFromFeedback } from '../../featur
 import { handleRelease } from '../../features/release.js';
 import { handleMemory } from '../../features/memory.js';
 import { recordOwnerDM } from '../../middleware/stats.js';
-import { GROUP_IDS, isFeatureEnabled } from '../../bot/groups.js';
+import { GROUP_IDS, isFeatureEnabled } from '../../core/groups-config.js';
 import { getResponse } from '../../core/response-router.js';
 
 function buildSupportMessage(): string {

--- a/src/platforms/whatsapp/processor.ts
+++ b/src/platforms/whatsapp/processor.ts
@@ -6,7 +6,7 @@ import { transcribeAudio } from '../../features/voice.js';
 import { handleIntroduction } from '../../features/introductions.js';
 import { handleEventPassive } from '../../features/events.js';
 import { config } from '../../utils/config.js';
-import { isGroupEnabled, getEnabledGroupJidByName } from '../../bot/groups.js';
+import { isGroupEnabled, getEnabledGroupJidByName } from '../../core/groups-config.js';
 import { handleOwnerDM } from './owner-commands.js';
 import { handleGroupMessage } from './group-handler.js';
 import { isReplyToBot, isAcknowledgment } from './reactions.js';

--- a/tests/core-group-parity.test.ts
+++ b/tests/core-group-parity.test.ts
@@ -24,7 +24,7 @@ function setupMocks() {
     },
   }));
 
-  vi.doMock('../src/bot/groups.js', () => ({
+  vi.doMock('../src/core/groups-config.js', () => ({
     GROUP_IDS: {
       'intro@g.us': { name: 'Introductions', enabled: true },
       'events@g.us': { name: 'Events', enabled: true },
@@ -32,11 +32,12 @@ function setupMocks() {
       'group-legacy@g.us': { name: 'General Legacy', enabled: true },
       'group-core@g.us': { name: 'General Core', enabled: true },
     },
+    MENTION_PATTERNS: ['@garbanzo'],
     requiresMention: vi.fn(() => true),
-    isMentioned: vi.fn(() => true),
-    stripMention: vi.fn((t: string) => t),
     getGroupName: vi.fn(() => 'General'),
     isFeatureEnabled,
+    isGroupEnabled: vi.fn(() => true),
+    getEnabledGroupJidByName: vi.fn(() => null),
   }));
 
   vi.doMock('../src/middleware/rate-limit.js', () => ({

--- a/tests/formatting-snapshots.test.ts
+++ b/tests/formatting-snapshots.test.ts
@@ -30,7 +30,7 @@ describe('Formatted output snapshots', () => {
       })),
     }));
 
-    vi.doMock('../src/bot/groups.js', () => ({
+    vi.doMock('../src/core/groups-config.js', () => ({
       getGroupName: vi.fn((jid: string) => {
         if (jid === 'general@g.us') return 'General';
         if (jid === 'events@g.us') return 'Events';

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -42,7 +42,7 @@ function mockHandlerDeps(): HandlerMocks {
     getSenderJid: vi.fn((_remoteJid: string, participant?: string) => participant ?? 'user@s.whatsapp.net'),
   }));
 
-  vi.doMock('../src/bot/groups.js', () => ({
+  vi.doMock('../src/core/groups-config.js', () => ({
     isGroupEnabled,
     isFeatureEnabled: vi.fn(() => true),
     getGroupName: vi.fn(() => 'General'),

--- a/tests/ops.test.ts
+++ b/tests/ops.test.ts
@@ -295,7 +295,7 @@ describe('Retry — dead letter queue', async () => {
 // ── Feature flags ───────────────────────────────────────────────────
 
 describe('Feature flags — per-group feature control', async () => {
-  const { isFeatureEnabled, isGroupEnabled, getGroupName } = await import('../src/bot/groups.js');
+  const { isFeatureEnabled, isGroupEnabled, getGroupName } = await import('../src/core/groups-config.js');
 
   it('allows all features when enabledFeatures is not set', () => {
     // General group has no enabledFeatures in config

--- a/tests/owner-commands.test.ts
+++ b/tests/owner-commands.test.ts
@@ -41,7 +41,7 @@ describe('owner support commands', () => {
     vi.doMock('../src/features/memory.js', () => ({ handleMemory: vi.fn(() => 'memory') }));
     vi.doMock('../src/middleware/stats.js', () => ({ recordOwnerDM: vi.fn() }));
     vi.doMock('../src/core/response-router.js', () => ({ getResponse: vi.fn(async () => 'ai') }));
-    vi.doMock('../src/bot/groups.js', () => ({
+    vi.doMock('../src/core/groups-config.js', () => ({
       GROUP_IDS: {
         'g1@g.us': { name: 'General', enabled: true },
         'g2@g.us': { name: 'Offtopic', enabled: true },

--- a/tests/phase6.test.ts
+++ b/tests/phase6.test.ts
@@ -325,7 +325,7 @@ describe('Router — new Phase 6 bang commands', async () => {
 // ── Feature flags — group-level control ─────────────────────────────
 
 describe('Feature flags — per-group persona', async () => {
-  const { getGroupPersona } = await import('../src/bot/groups.js');
+  const { getGroupPersona } = await import('../src/core/groups-config.js');
 
   it('returns persona for configured groups', () => {
     const generalJid = '120363423357339667@g.us';

--- a/tests/release.test.ts
+++ b/tests/release.test.ts
@@ -7,7 +7,7 @@ describe('release notes helper', () => {
   });
 
   function mockReleaseDeps() {
-    vi.doMock('../src/bot/groups.js', () => ({
+    vi.doMock('../src/core/groups-config.js', () => ({
       GROUP_IDS: {
         'general@g.us': { name: 'General', enabled: true },
         'events@g.us': { name: 'Events', enabled: true },

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -49,7 +49,7 @@ describe('Formatting utilities', async () => {
 });
 
 describe('Mention detection', async () => {
-  const { isMentioned, stripMention } = await import('../src/bot/groups.js');
+  const { isMentioned, stripMention } = await import('../src/platforms/whatsapp/mentions.js');
 
   it('detects text-based @garbanzo mention', () => {
     expect(isMentioned('hey @garbanzo what is the weather')).toBe(true);


### PR DESCRIPTION
## Objective
Move group configuration and feature flag logic into `src/core/` so it can be shared across platforms, and keep WhatsApp-only mention parsing in the WhatsApp platform.

Closes: n/a

## Problem
- Group config (`config/groups.json`) parsing and helpers lived in `src/bot/groups.ts`.
- Many non-bot modules (features, persona) depended on these helpers.
- WhatsApp mention parsing was mixed into the group config helper, even though it is platform-specific.

## Solution
- Move config parsing + generic helpers to `src/core/groups-config.ts`:
  - `GROUP_IDS`, `MENTION_PATTERNS`
  - `isGroupEnabled`, `getGroupName`, `getEnabledGroupJidByName`
  - `isFeatureEnabled`, `requiresMention`, `getGroupPersona`
- Add WhatsApp-only mention helpers to `src/platforms/whatsapp/mentions.ts`:
  - `isMentioned`, `stripMention`
- Update callsites and tests accordingly.

## User-Facing Impact
- No intended behavior change.

## Verification
- [x] `npm run check`