### PR TITLE
feat: add Slack platform skeleton

### DIFF
--- a/src/platforms/slack/adapter.ts
+++ b/src/platforms/slack/adapter.ts
@@ -1,0 +1,45 @@
+import type { MessagingAdapter } from '../../core/messaging-adapter.js';
+import type { PlatformMessenger, DocumentPayload, AudioPayload } from '../../core/platform-messenger.js';
+
+/**
+ * Slack adapter skeleton.
+ *
+ * This intentionally throws for all operations until the Slack runtime is implemented.
+ * It exists to validate the platform/core boundaries at compile-time.
+ */
+export function createSlackAdapter(): PlatformMessenger {
+  const err = () => new Error('Slack platform is not implemented');
+
+  const adapter: PlatformMessenger = {
+    platform: 'slack',
+
+    async sendText(): Promise<void> {
+      throw err();
+    },
+
+    async sendPoll(): Promise<void> {
+      throw err();
+    },
+
+    async sendTextWithRef(): Promise<unknown> {
+      throw err();
+    },
+
+    async sendDocument(_chatId: string, _doc: DocumentPayload): Promise<unknown> {
+      throw err();
+    },
+
+    async sendAudio(_chatId: string, _audio: AudioPayload): Promise<void> {
+      throw err();
+    },
+
+    async deleteMessage(): Promise<void> {
+      throw err();
+    },
+  };
+
+  // Ensure we still satisfy the minimal MessagingAdapter contract
+  void (adapter satisfies MessagingAdapter);
+
+  return adapter;
+}

--- a/src/platforms/slack/inbound.ts
+++ b/src/platforms/slack/inbound.ts
@@ -1,0 +1,12 @@
+import type { InboundMessage } from '../../core/inbound-message.js';
+
+/**
+ * Slack inbound message (normalized).
+ *
+ * Slack support is not implemented yet; this type is a placeholder to help
+ * build platform-agnostic core logic without committing to a specific Slack SDK.
+ */
+export interface SlackInbound extends InboundMessage {
+  platform: 'slack';
+  raw: unknown;
+}

--- a/src/platforms/slack/processor.ts
+++ b/src/platforms/slack/processor.ts
@@ -1,0 +1,12 @@
+import { logger } from '../../middleware/logger.js';
+
+/**
+ * Slack processor skeleton.
+ *
+ * This will eventually normalize Slack events into `SlackInbound` and
+ * pass them through the core inbound pipeline.
+ */
+export async function processSlackEvent(_event: unknown): Promise<void> {
+  logger.fatal({ platform: 'slack' }, 'Slack processor is not implemented yet');
+  throw new Error('Slack processor is not implemented');
+}

--- a/src/platforms/slack/runtime.ts
+++ b/src/platforms/slack/runtime.ts
@@ -5,7 +5,10 @@ export function createSlackRuntime(): PlatformRuntime {
   return {
     platform: 'slack',
     async start(): Promise<void> {
-      logger.fatal({ platform: 'slack' }, 'Slack runtime is not implemented yet');
+      logger.fatal(
+        { platform: 'slack' },
+        'Slack runtime is not implemented yet (set MESSAGING_PLATFORM=whatsapp)',
+      );
       throw new Error('Slack runtime is not implemented');
     },
   };


### PR DESCRIPTION
## Objective
Add a compile-time Slack platform skeleton so we can keep pushing core/platform seams without committing to a Slack SDK yet.

Closes: n/a

## What Changed
- Added Slack placeholder modules:
  - `src/platforms/slack/adapter.ts` (throws for now)
  - `src/platforms/slack/inbound.ts` (normalized type placeholder)
  - `src/platforms/slack/processor.ts` (throws for now)
- Improved the Slack runtime fatal log message to be more actionable.

## User-Facing Impact
- None unless `MESSAGING_PLATFORM=slack` is selected (still fails fast).

## Verification
- [x] `npm run check`