### PR TITLE
refactor: move MessagingPlatform type into core

### DIFF
--- a/src/core/inbound-message.ts
+++ b/src/core/inbound-message.ts
@@ -1,4 +1,4 @@
-import type { MessagingPlatform } from '../platforms/types.js';
+import type { MessagingPlatform } from './messaging-platform.js';
 
 /**
  * Normalized inbound message.

--- a/src/core/messaging-adapter.ts
+++ b/src/core/messaging-adapter.ts
@@ -1,4 +1,4 @@
-import type { MessagingPlatform } from '../platforms/types.js';
+import type { MessagingPlatform } from './messaging-platform.js';
 
 /**
  * Messaging adapter API.

--- a/src/core/messaging-platform.ts
+++ b/src/core/messaging-platform.ts
@@ -1,0 +1,1 @@
+export type MessagingPlatform = 'whatsapp' | 'discord' | 'slack' | 'teams';

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -1,6 +1,6 @@
-export type MessagingPlatform = 'whatsapp' | 'discord' | 'slack' | 'teams';
+export type { MessagingPlatform } from '../core/messaging-platform.js';
 
 export interface PlatformRuntime {
-  platform: MessagingPlatform;
+  platform: import('../core/messaging-platform.js').MessagingPlatform;
   start(): Promise<void>;
 }


### PR DESCRIPTION
## Objective
Move the `MessagingPlatform` type into `src/core/` so core types do not depend on the platforms folder.

Closes: n/a

## What Changed
- Added `src/core/messaging-platform.ts`.
- Updated `src/core/messaging-adapter.ts` and `src/core/inbound-message.ts` to import the type from core.
- Kept `src/platforms/types.ts` backwards compatible by re-exporting the type from core.

## User-Facing Impact
- None.

## Verification
- [x] `npm run check`