### PR TITLE
docs: align README and contributor docs with core/platform layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,10 @@ Each feature lives in its own file under `src/features/`:
 1. Create `src/features/your-feature.ts`
 2. Add bang command(s) to `BANG_COMMANDS` in `src/features/router.ts`
 3. Add natural language patterns to `FEATURE_PATTERNS` if appropriate
-4. Wire into `src/bot/handlers.ts`
+4. Wire into core routing:
+   - DM / generic routing: `src/core/response-router.ts`
+   - Group-only flows (polls, attachments, richer interactions): `src/core/process-group-message.ts`
+   - Platform-specific preprocessing (mentions/media/etc.): `src/platforms/<platform>/*`
 5. Write tests in `tests/`
 6. Update `src/features/help.ts` with the new command(s)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -133,13 +133,13 @@
 
 ### High Priority (low effort, high value)
 1. ~~**Health check HTTP endpoint** (`src/middleware/health.ts`) — HTTP server on `http://127.0.0.1:3001/health` by default, returns JSON: connection status, uptime, staleness, last message age, reconnect count, memory usage~~ ✅ Live
-2. ~~**Connection staleness detection** (`src/bot/connection.ts`) — tracks `lastMessageReceivedAt` via health module, auto-reconnect if >30 min with no messages. Checks every 5 min. Prevents "connected but deaf" failure mode~~ ✅ Live
+2. ~~**Connection staleness detection** (`src/platforms/whatsapp/connection.ts`) — tracks `lastMessageReceivedAt` via health module, auto-reconnect if >30 min with no messages. Checks every 5 min. Prevents "connected but deaf" failure mode~~ ✅ Live
 3. ~~**Ollama warm-up ping** (`src/ai/ollama.ts`) — sends `/api/generate` keep-alive with `keep_alive: 15m` every 10 min to prevent model unload. Immediate ping on startup~~ ✅ Live
 4. ~~**SQLite auto-vacuum** (`src/utils/db.ts`) — scheduled daily at 4 AM: prune messages older than 30 days + `VACUUM` to reclaim space~~ ✅ Live
 
 ### Medium Priority (medium effort, high value)
 5. ~~**Cost tracking** (`src/middleware/stats.ts`) — estimates tokens per Claude call (~4 chars/token heuristic), accumulates daily spend, logs per-call cost + daily total. Alert threshold at $1/day (logged, surfaced in digest)~~ ✅ Live
-6. ~~**Feature flags per group** (`src/bot/groups.ts`, `config/groups.json`) — optional `enabledFeatures` array per group. If omitted, all features enabled (backward compatible). Checked before routing to any feature handler~~ ✅ Live
+6. ~~**Feature flags per group** (`src/core/groups-config.ts`, `config/groups.json`) — optional `enabledFeatures` array per group. If omitted, all features enabled (backward compatible). Checked before routing to any feature handler~~ ✅ Live
 7. ~~**Dead letter retry** (`src/middleware/retry.ts`) — in-memory queue, messages that fail AI processing retried once after 30s. Max 50 entries, dedup by sender+group+timestamp. Cleared on shutdown~~ ✅ Live
 8. ~~**Automated SQLite backup** (`src/utils/db.ts`) — nightly at 4 AM (before vacuum): `VACUUM INTO` for WAL-safe snapshot to `data/backups/garbanzo-YYYY-MM-DD.db`, keep last 7, prune older~~ ✅ Live
 
@@ -231,7 +231,7 @@ Completed as part of 7.1 file splits:
 1. [x] Replace remaining `any` types — `connection.ts` (`as any` → `as ILogger`), `media.ts` (`Record<string, any>` → `WAMessageContent`), `claude.ts` (typed `ContentBlock` discriminated union for Anthropic/OpenRouter image formats)
 2. [x] Add Zod schemas for external API responses — `weather.ts` (3 schemas), `news.ts` (2), `venues.ts` (4), `books.ts` (3 + refactored `olFetch<T>` with schema param), `claude.ts` (inline `.safeParse()` for both API formats). Skipped `transit.ts` (already typed), `fun.ts`/`dnd-lookups.ts` (lower priority)
 3. [x] Create shared `Result<T, E>` type in `src/utils/formatting.ts` for feature handlers returning text or structured data
-4. [x] Type `config/groups.json` with Zod — `GroupConfigSchema` + `GroupsConfigSchema` in `src/bot/groups.ts`, validated with `.parse()` at startup
+4. [x] Type `config/groups.json` with Zod — `GroupConfigSchema` + `GroupsConfigSchema` in `src/core/groups-config.ts`, validated with `.parse()` at startup
 
 ### 7.5 — Test improvements ✅
 


### PR DESCRIPTION
## Objective

Align README and contributor docs with the new core/platform folder layout.

Closes:

## Problem

- Several docs still referenced `src/bot/*` after the refactor to `src/core/*` + `src/platforms/*`.
- This made feature wiring guidance and roadmap items misleading.

## Solution

- `README.md`: update architecture overview and platform list.
- `CONTRIBUTING.md`: update guidance for where to wire new behavior.
- `docs/ROADMAP.md`: fix legacy path references.

## User-Facing Impact

- Smoother onboarding for contributors and fewer broken links.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs-only)

## Risk and Rollback

- Risk level: low
- Primary risk: doc drift if more refactors land
- Rollback approach: revert commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `README.md`
2. `CONTRIBUTING.md`
3. `docs/ROADMAP.md`