### PR TITLE
fix: keep /health/ready from sticking stale after reconnect

### DIFF
--- a/docs/DOCKERHUB_OVERVIEW.md
+++ b/docs/DOCKERHUB_OVERVIEW.md
@@ -37,6 +37,8 @@ Readiness (non-200 when disconnected/stale):
 curl -i http://127.0.0.1:3001/health/ready
 ```
 
+Troubleshooting: if `/health` reports `status=connected` but `/health/ready` is 503 with `stale=true` immediately after a reconnect, you are likely running an older build where staleness was carried over across reconnects. Upgrade to a newer release, or as a short-term workaround send any message in a monitored chat to refresh `lastMessageAt`.
+
 ## Tags
 
 This repo publishes both GHCR and Docker Hub tags.

--- a/src/middleware/health.ts
+++ b/src/middleware/health.ts
@@ -38,12 +38,18 @@ const state: ConnectionState = {
 
 /** Call when WhatsApp connection opens */
 export function markConnected(): void {
-  if (state.status === 'connected' && state.connectedAt !== null) {
-    // Reconnection — increment counter
+  // Count reconnects when we have previously been connected in this process.
+  if (state.connectedAt !== null) {
     state.reconnectCount++;
   }
+
   state.status = 'connected';
   state.connectedAt = Date.now();
+
+  // Reset message freshness on reconnect.
+  // Otherwise, a stale `lastMessageAt` from a prior connection can cause `/health/ready`
+  // to remain 503 until a new message arrives.
+  state.lastMessageAt = null;
 }
 
 /** Call when WhatsApp connection closes */

--- a/tests/ops.test.ts
+++ b/tests/ops.test.ts
@@ -67,6 +67,22 @@ describe('Health — connection state tracking', async () => {
     markConnected();
     expect(getConnectionState().reconnectCount).toBeGreaterThanOrEqual(1);
   });
+
+  it('resets lastMessageAt on reconnect so readiness does not stick stale', () => {
+    markConnected();
+    markMessageReceived();
+    expect(getConnectionState().lastMessageAt).toBeTypeOf('number');
+
+    const baselineReconnects = getConnectionState().reconnectCount;
+
+    markDisconnected();
+    markConnected();
+
+    const state = getConnectionState();
+    expect(state.lastMessageAt).toBe(null);
+    expect(state.reconnectCount).toBe(baselineReconnects + 1);
+    expect(isConnectionStale()).toBe(false);
+  });
 });
 
 describe('Health endpoint — backup status and rate limiting', async () => {


### PR DESCRIPTION
## Objective

Prevent `/health/ready` from sticking in `stale=true` immediately after a successful WhatsApp reconnect.

Closes:

## Problem

- We observed Baileys reconnecting successfully, but readiness remained 503 because a stale `lastMessageAt` value carried over across reconnects.
- This caused Kuma (and operators) to treat the bot as unhealthy until any new inbound message arrived.

## Solution

- `src/middleware/health.ts`: reset `lastMessageAt` to `null` in `markConnected()` so staleness is evaluated from the new connection time.
- `tests/ops.test.ts`: add a regression test covering reconnect behavior.
- `docs/DOCKERHUB_OVERVIEW.md`: document the symptom + upgrade/workaround.

## User-Facing Impact

- More accurate readiness semantics: a reconnecting bot becomes ready immediately rather than waiting for a new message.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- Rebuilt dev image and confirmed `/health/ready` returns 200 after reconnect without requiring a message.

## Risk and Rollback

- Risk level: low
- Primary risk: readiness could briefly report ready before a real inbound message is received (acceptable; staleness is based on message flow, not socket open).
- Rollback approach: revert commit and redeploy.

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `src/middleware/health.ts`
2. `tests/ops.test.ts`