### PR TITLE
feat: add local Slack demo runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@
 
 # ── Messaging Platform ───────────────────────
 # Supported now: whatsapp
+# Slack is scaffolded; for a local-only demo runtime, set:
+#   MESSAGING_PLATFORM=slack
+#   SLACK_DEMO=true
 # Planned: discord (Phase 8)
 MESSAGING_PLATFORM=whatsapp
 
@@ -74,6 +77,13 @@ HEALTH_BIND_HOST=127.0.0.1
 
 # Prometheus-style metrics (served from the health server at /metrics)
 METRICS_ENABLED=false
+
+# ── Slack demo runtime (local dev only) ───────
+# Starts an HTTP server that lets you POST "fake Slack messages" and see
+# what Garbanzo would send back, without needing real Slack APIs.
+SLACK_DEMO=false
+SLACK_DEMO_PORT=3002
+SLACK_DEMO_BIND_HOST=127.0.0.1
 
 # Log level: debug | info | warn | error
 LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ npm run dev
 # Scan the QR code with WhatsApp when prompted
 ```
 
+### Slack Demo Mode (optional)
+
+Slack is scaffolded but not implemented as a real runtime yet. For local development, you can run a small HTTP demo server that exercises the core pipeline without Slack APIs:
+
+```bash
+# .env
+MESSAGING_PLATFORM=slack
+SLACK_DEMO=true
+
+npm run dev
+
+# In another terminal
+curl -s -X POST http://127.0.0.1:3002/slack/demo \
+  -H 'content-type: application/json' \
+  -d '{"chatId":"C123","senderId":"U123","text":"@garbanzo !help"}'
+```
+
 ### Automated / Non-Interactive Setup
 
 Use non-interactive mode for reproducible setup in scripts or CI-like environments:

--- a/src/platforms/slack/adapter.ts
+++ b/src/platforms/slack/adapter.ts
@@ -9,6 +9,12 @@ import type { PlatformMessenger, DocumentPayload, AudioPayload } from '../../cor
  * This intentionally throws for all operations until the Slack runtime is implemented.
  * It exists to validate the platform/core boundaries at compile-time.
  */
+export interface SlackDemoOutboxEntry {
+  type: 'text' | 'poll' | 'document' | 'audio' | 'delete';
+  chatId: string;
+  payload: unknown;
+}
+
 export function createSlackAdapter(): PlatformMessenger {
   const err = () => new Error('Slack platform is not implemented');
 
@@ -41,6 +47,79 @@ export function createSlackAdapter(): PlatformMessenger {
   };
 
   // Ensure we still satisfy the minimal MessagingAdapter contract
+  void (adapter satisfies MessagingAdapter);
+
+  return adapter;
+}
+
+/**
+ * A tiny in-process adapter used to exercise core routing without Slack APIs.
+ *
+ * This is intended for local development only ("demo mode"), not for production.
+ */
+export function createSlackDemoAdapter(outbox: SlackDemoOutboxEntry[]): PlatformMessenger {
+  const nextRef = (chatId: string): MessageRef => ({
+    platform: 'slack-demo',
+    chatId,
+    id: `demo-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  });
+
+  const adapter: PlatformMessenger = {
+    platform: 'slack',
+
+    async sendText(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<void> {
+      outbox.push({
+        type: 'text',
+        chatId,
+        payload: { text, replyTo: options?.replyTo ?? null },
+      });
+    },
+
+    async sendPoll(chatId: string, poll: PollPayload): Promise<void> {
+      outbox.push({
+        type: 'poll',
+        chatId,
+        payload: poll,
+      });
+    },
+
+    async sendTextWithRef(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<MessageRef> {
+      const ref = nextRef(chatId);
+      outbox.push({
+        type: 'text',
+        chatId,
+        payload: { text, replyTo: options?.replyTo ?? null, ref },
+      });
+      return ref;
+    },
+
+    async sendDocument(chatId: string, doc: DocumentPayload): Promise<MessageRef> {
+      const ref = nextRef(chatId);
+      outbox.push({
+        type: 'document',
+        chatId,
+        payload: { fileName: doc.fileName, mimetype: doc.mimetype, bytesLength: doc.bytes.length, ref },
+      });
+      return ref;
+    },
+
+    async sendAudio(chatId: string, audio: AudioPayload, options?: { replyTo?: unknown }): Promise<void> {
+      outbox.push({
+        type: 'audio',
+        chatId,
+        payload: { mimetype: audio.mimetype, ptt: audio.ptt ?? false, bytesLength: audio.bytes.length, replyTo: options?.replyTo ?? null },
+      });
+    },
+
+    async deleteMessage(chatId: string, messageRef: MessageRef): Promise<void> {
+      outbox.push({
+        type: 'delete',
+        chatId,
+        payload: { messageRef },
+      });
+    },
+  };
+
   void (adapter satisfies MessagingAdapter);
 
   return adapter;

--- a/src/platforms/slack/demo-server.ts
+++ b/src/platforms/slack/demo-server.ts
@@ -1,0 +1,98 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+import { logger } from '../../middleware/logger.js';
+import { config } from '../../utils/config.js';
+
+import { createSlackDemoAdapter, type SlackDemoOutboxEntry } from './adapter.js';
+import { parseSlackDemoMessage, normalizeSlackDemoInbound, processSlackDemoInbound } from './processor.js';
+
+export function createSlackDemoServer(params: {
+  host: string;
+  port: number;
+}): ReturnType<typeof createServer> {
+  const server = createServer(async (req, res) => {
+    try {
+      if (!req.url || !req.method) {
+        writeJson(res, 400, { ok: false, error: 'Missing request URL/method' });
+        return;
+      }
+
+      if (req.method === 'GET' && (req.url === '/' || req.url === '/slack/demo')) {
+        writeJson(res, 200, {
+          ok: true,
+          message: 'Slack demo server is running',
+          postTo: '/slack/demo',
+          example: {
+            curl: "curl -s -X POST http://127.0.0.1:" + params.port + "/slack/demo \\\n  -H 'content-type: application/json' \\\n  -d '{\"chatId\":\"C123\",\"senderId\":\"U123\",\"text\":\"@garbanzo !help\"}' | jq",
+          },
+        });
+        return;
+      }
+
+      if (req.method !== 'POST' || req.url !== '/slack/demo') {
+        writeJson(res, 404, { ok: false, error: 'Not found' });
+        return;
+      }
+
+      const body = await readJsonBody(req, 256_000);
+      const msg = parseSlackDemoMessage(body);
+
+      const inbound = normalizeSlackDemoInbound(msg);
+      const outbox: SlackDemoOutboxEntry[] = [];
+      const messenger = createSlackDemoAdapter(outbox);
+
+      await processSlackDemoInbound(messenger, inbound, { ownerId: config.OWNER_JID });
+
+      writeJson(res, 200, {
+        ok: true,
+        inbound: {
+          chatId: inbound.chatId,
+          senderId: inbound.senderId,
+          messageId: inbound.messageId,
+          isGroupChat: inbound.isGroupChat,
+        },
+        outbox,
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error({ err, platform: 'slack', path: req.url }, 'Slack demo request failed');
+      writeJson(res, 500, { ok: false, error });
+    }
+  });
+
+  server.listen(params.port, params.host, () => {
+    logger.info({ host: params.host, port: params.port }, 'Slack demo server listening');
+  });
+
+  return server;
+}
+
+async function readJsonBody(req: IncomingMessage, maxBytes: number): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) {
+      throw new Error(`Request body too large (max ${maxBytes} bytes)`);
+    }
+    chunks.push(buf);
+  }
+
+  const raw = Buffer.concat(chunks).toString('utf-8').trim();
+  if (!raw) return {};
+
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error('Invalid JSON body');
+  }
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body, null, 2);
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json; charset=utf-8');
+  res.end(json);
+}

--- a/src/platforms/slack/processor.ts
+++ b/src/platforms/slack/processor.ts
@@ -1,4 +1,12 @@
+import { z } from 'zod';
+
 import { logger } from '../../middleware/logger.js';
+import { processInboundMessage } from '../../core/process-inbound-message.js';
+import { processGroupMessage } from '../../core/process-group-message.js';
+import { getResponse } from '../../core/response-router.js';
+import type { PlatformMessenger } from '../../core/platform-messenger.js';
+import type { SlackInbound } from './inbound.js';
+import { isFeatureEnabled } from '../../core/groups-config.js';
 
 /**
  * Slack processor skeleton.
@@ -9,4 +17,111 @@ import { logger } from '../../middleware/logger.js';
 export async function processSlackEvent(_event: unknown): Promise<void> {
   logger.fatal({ platform: 'slack' }, 'Slack processor is not implemented yet');
   throw new Error('Slack processor is not implemented');
+}
+
+const SlackDemoMessageSchema = z.object({
+  chatId: z.string().min(1),
+  senderId: z.string().min(1),
+  text: z.string().default(''),
+  isGroupChat: z.coerce.boolean().default(true),
+  groupName: z.string().optional(),
+});
+
+export type SlackDemoMessage = z.infer<typeof SlackDemoMessageSchema>;
+
+export function normalizeSlackDemoInbound(message: SlackDemoMessage): SlackInbound {
+  return {
+    platform: 'slack',
+    chatId: message.chatId,
+    senderId: message.senderId,
+    messageId: `slack-demo-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    fromSelf: false,
+    isStatusBroadcast: false,
+    isGroupChat: message.isGroupChat,
+    timestampMs: Date.now(),
+    text: message.text,
+    hasVisualMedia: false,
+    raw: message,
+  };
+}
+
+export function parseSlackDemoMessage(input: unknown): SlackDemoMessage {
+  return SlackDemoMessageSchema.parse(input);
+}
+
+/**
+ * Slack "demo mode" processor.
+ *
+ * This exists to validate core/platform wiring without pulling in Slack SDKs.
+ */
+export async function processSlackDemoInbound(
+  messenger: PlatformMessenger,
+  inbound: SlackInbound,
+  env: {
+    ownerId: string;
+  },
+): Promise<void> {
+  await processInboundMessage(messenger, inbound, {
+    isReplyToBot: () => false,
+
+    isAcknowledgment: () => false,
+
+    sendAcknowledgmentReaction: async () => {
+      // no-op for demo
+    },
+
+    handleGroupMessage: async ({ inbound: m, text, hasMedia }) => {
+      const trimmed = text.trim();
+      const mentionMatch = /^@garbanzo\b[:\s]*/i.exec(trimmed);
+      const isBang = trimmed.startsWith('!');
+
+      // Keep behavior closer to WhatsApp: ignore unless explicitly invoked.
+      if (!mentionMatch && !isBang) return;
+
+      let query = trimmed;
+      if (isBang) {
+        query = trimmed;
+      } else if (mentionMatch) {
+        query = trimmed.slice(mentionMatch[0].length).trim();
+      }
+
+      if (!query && !hasMedia) return;
+
+      await processGroupMessage({
+        messenger,
+        chatId: m.chatId,
+        senderId: m.senderId,
+        groupName: 'Slack (demo)',
+        ownerId: env.ownerId,
+        query,
+        isFeatureEnabled,
+        getResponse,
+        messageId: m.messageId,
+        replyTo: m.raw,
+      });
+    },
+
+    handleOwnerDM: async ({ inbound: m, text }) => {
+      const response = await getResponse(
+        text,
+        {
+          groupName: 'Slack DM (demo)',
+          groupJid: m.chatId,
+          senderJid: m.senderId,
+        },
+        isFeatureEnabled,
+      );
+
+      if (response) {
+        await messenger.sendText(m.chatId, response, { replyTo: m.raw });
+      }
+    },
+  }, {
+    ownerId: env.ownerId,
+    isGroupEnabled: () => true,
+    introductionsChatId: null,
+    eventsChatId: null,
+    handleIntroduction: async () => null,
+    handleEventPassive: async () => null,
+  });
 }

--- a/src/platforms/slack/runtime.ts
+++ b/src/platforms/slack/runtime.ts
@@ -1,15 +1,30 @@
 import { logger } from '../../middleware/logger.js';
+import { config } from '../../utils/config.js';
 import type { PlatformRuntime } from '../types.js';
+
+import { createSlackDemoServer } from './demo-server.js';
 
 export function createSlackRuntime(): PlatformRuntime {
   return {
     platform: 'slack',
     async start(): Promise<void> {
-      logger.fatal(
-        { platform: 'slack' },
-        'Slack runtime is not implemented yet (set MESSAGING_PLATFORM=whatsapp)',
+      if (!config.SLACK_DEMO) {
+        logger.fatal(
+          { platform: 'slack' },
+          'Slack runtime is not implemented (set MESSAGING_PLATFORM=whatsapp, or SLACK_DEMO=true for local demo mode)',
+        );
+        throw new Error('Slack runtime is not implemented');
+      }
+
+      createSlackDemoServer({
+        host: config.SLACK_DEMO_BIND_HOST,
+        port: config.SLACK_DEMO_PORT,
+      });
+
+      logger.info(
+        { host: config.SLACK_DEMO_BIND_HOST, port: config.SLACK_DEMO_PORT },
+        'Slack demo mode started (local dev only)',
       );
-      throw new Error('Slack runtime is not implemented');
     },
   };
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -57,6 +57,11 @@ const envSchema = z.object({
   HEALTH_BIND_HOST: z.string().min(1).default('127.0.0.1'),
   METRICS_ENABLED: z.coerce.boolean().default(false),
 
+  // Slack demo runtime (non-production)
+  SLACK_DEMO: z.coerce.boolean().default(false),
+  SLACK_DEMO_PORT: z.coerce.number().int().min(1).max(65535).default(3002),
+  SLACK_DEMO_BIND_HOST: z.string().min(1).default('127.0.0.1'),
+
   // Database
   DB_DIALECT: z.enum(['sqlite', 'postgres']).default('sqlite'),
   DATABASE_URL: z.string().optional(),

--- a/tests/slack-demo.test.ts
+++ b/tests/slack-demo.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+import { createSlackDemoAdapter } from '../src/platforms/slack/adapter.js';
+import { normalizeSlackDemoInbound, processSlackDemoInbound } from '../src/platforms/slack/processor.js';
+
+describe('Slack demo runtime', () => {
+  it('routes @garbanzo !help through the core pipeline', async () => {
+    const outbox: Array<{ type: string; chatId: string; payload: unknown }> = [];
+    const messenger = createSlackDemoAdapter(outbox);
+
+    const inbound = normalizeSlackDemoInbound({
+      chatId: 'C123',
+      senderId: 'U123',
+      text: '@garbanzo !help',
+      isGroupChat: true,
+    });
+
+    await processSlackDemoInbound(messenger, inbound, { ownerId: 'owner@s.whatsapp.net' });
+
+    expect(outbox.length).toBeGreaterThan(0);
+    const first = outbox[0];
+    expect(first.type).toBe('text');
+
+    const payload = first.payload as { text?: unknown };
+    expect(typeof payload.text).toBe('string');
+    expect(String(payload.text)).toContain('Garbanzo Bean');
+  });
+});


### PR DESCRIPTION
## Objective

Add a local-only Slack demo runtime to exercise the core inbound/group pipeline without Slack APIs.

Closes:

## Problem

- Slack is scaffolded, but without a minimal runtime it was hard to validate the core/platform seams without pulling in Slack SDKs or credentials.

## Solution

- Add env flags: `SLACK_DEMO`, `SLACK_DEMO_PORT`, `SLACK_DEMO_BIND_HOST`.
- `src/platforms/slack/runtime.ts`: if `SLACK_DEMO=true`, start an HTTP demo server.
- `src/platforms/slack/demo-server.ts`: GET `/slack/demo` (info) and POST `/slack/demo` to submit a fake message and return an outbox of what Garbanzo would send.
- `tests/slack-demo.test.ts`: basic routing coverage (`@garbanzo !help`).
- Docs: `README.md` and `.env.example` updated with demo instructions.

## User-Facing Impact

- None for production users (demo mode only). Developers can now test core routing via HTTP without Slack APIs.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- POSTed `@garbanzo !help` to `http://127.0.0.1:3002/slack/demo` and confirmed outbox contains a help response.

## Risk and Rollback

- Risk level: low
- Primary risk: accidental use in production if enabled via env
- Rollback approach: revert commit; keep Slack runtime fail-fast.

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `src/platforms/slack/runtime.ts`
2. `src/platforms/slack/demo-server.ts`
3. `src/platforms/slack/processor.ts`