### PR TITLE
refactor: type replyTo as MessageRef across messengers

### DIFF
--- a/src/core/inbound-message.ts
+++ b/src/core/inbound-message.ts
@@ -1,4 +1,5 @@
 import type { MessagingPlatform } from './messaging-platform.js';
+import type { MessageRef } from './message-ref.js';
 
 /**
  * Normalized inbound message.
@@ -40,5 +41,5 @@ export interface InboundMessage {
   hasVisualMedia: boolean;
 
   /** Platform-specific raw message for advanced operations. */
-  raw: unknown;
+  raw: MessageRef;
 }

--- a/src/core/messaging-adapter.ts
+++ b/src/core/messaging-adapter.ts
@@ -1,4 +1,5 @@
 import type { MessagingPlatform } from './messaging-platform.js';
+import type { MessageRef } from './message-ref.js';
 
 /**
  * Messaging adapter API.
@@ -9,5 +10,5 @@ import type { MessagingPlatform } from './messaging-platform.js';
 export interface MessagingAdapter {
   platform: MessagingPlatform;
 
-  sendText(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<void>;
+  sendText(chatId: string, text: string, options?: { replyTo?: MessageRef }): Promise<void>;
 }

--- a/src/core/platform-messenger.ts
+++ b/src/core/platform-messenger.ts
@@ -24,12 +24,12 @@ export interface PlatformMessenger extends MessagingAdapter {
   sendPoll(chatId: string, poll: PollPayload): Promise<void>;
 
   /** Returns a platform-specific message ref for optional deletes. */
-  sendTextWithRef(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<MessageRef>;
+  sendTextWithRef(chatId: string, text: string, options?: { replyTo?: MessageRef }): Promise<MessageRef>;
 
   /** Returns a platform-specific message ref for optional deletes. */
   sendDocument(chatId: string, doc: DocumentPayload): Promise<MessageRef>;
 
-  sendAudio(chatId: string, audio: AudioPayload, options?: { replyTo?: unknown }): Promise<void>;
+  sendAudio(chatId: string, audio: AudioPayload, options?: { replyTo?: MessageRef }): Promise<void>;
 
   deleteMessage(chatId: string, messageRef: MessageRef): Promise<void>;
 }

--- a/src/core/process-group-message.ts
+++ b/src/core/process-group-message.ts
@@ -11,6 +11,7 @@ import { recordBotResponse } from '../middleware/stats.js';
 import { queueRetry } from '../middleware/retry.js';
 import type { MessageContext } from '../ai/persona.js';
 import type { VisionImage } from './vision.js';
+import type { MessageRef } from './message-ref.js';
 import type { PlatformMessenger } from './platform-messenger.js';
 
 export interface ProcessGroupMessageParams {
@@ -34,7 +35,7 @@ export interface ProcessGroupMessageParams {
 
   quotedText?: string;
   messageId?: string;
-  replyTo?: unknown;
+  replyTo?: MessageRef;
 
   visionImages?: VisionImage[];
 }

--- a/src/platforms/slack/adapter.ts
+++ b/src/platforms/slack/adapter.ts
@@ -67,7 +67,7 @@ export function createSlackDemoAdapter(outbox: SlackDemoOutboxEntry[]): Platform
   const adapter: PlatformMessenger = {
     platform: 'slack',
 
-    async sendText(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<void> {
+    async sendText(chatId: string, text: string, options?: { replyTo?: MessageRef }): Promise<void> {
       outbox.push({
         type: 'text',
         chatId,
@@ -83,7 +83,7 @@ export function createSlackDemoAdapter(outbox: SlackDemoOutboxEntry[]): Platform
       });
     },
 
-    async sendTextWithRef(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<MessageRef> {
+    async sendTextWithRef(chatId: string, text: string, options?: { replyTo?: MessageRef }): Promise<MessageRef> {
       const ref = nextRef(chatId);
       outbox.push({
         type: 'text',
@@ -103,7 +103,7 @@ export function createSlackDemoAdapter(outbox: SlackDemoOutboxEntry[]): Platform
       return ref;
     },
 
-    async sendAudio(chatId: string, audio: AudioPayload, options?: { replyTo?: unknown }): Promise<void> {
+    async sendAudio(chatId: string, audio: AudioPayload, options?: { replyTo?: MessageRef }): Promise<void> {
       outbox.push({
         type: 'audio',
         chatId,

--- a/src/platforms/whatsapp/adapter.ts
+++ b/src/platforms/whatsapp/adapter.ts
@@ -7,12 +7,12 @@ export function createWhatsAppAdapter(sock: WASocket): PlatformMessenger {
   return {
     platform: 'whatsapp',
 
-    async sendText(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<void> {
+    async sendText(chatId: string, text: string, options?: { replyTo?: MessageRef }): Promise<void> {
       const replyTo = options?.replyTo as WAMessage | undefined;
       await sock.sendMessage(chatId, { text }, replyTo ? { quoted: replyTo } : undefined);
     },
 
-    async sendTextWithRef(chatId: string, text: string, options?: { replyTo?: unknown }): Promise<MessageRef> {
+    async sendTextWithRef(chatId: string, text: string, options?: { replyTo?: MessageRef }): Promise<MessageRef> {
       const replyTo = options?.replyTo as WAMessage | undefined;
       return await sock.sendMessage(chatId, { text }, replyTo ? { quoted: replyTo } : undefined);
     },
@@ -30,7 +30,7 @@ export function createWhatsAppAdapter(sock: WASocket): PlatformMessenger {
       });
     },
 
-    async sendAudio(chatId: string, audio: { bytes: Uint8Array; mimetype: string; ptt?: boolean }, options?: { replyTo?: unknown }): Promise<void> {
+    async sendAudio(chatId: string, audio: { bytes: Uint8Array; mimetype: string; ptt?: boolean }, options?: { replyTo?: MessageRef }): Promise<void> {
       const replyTo = options?.replyTo as WAMessage | undefined;
       await sock.sendMessage(chatId, {
         audio: Buffer.from(audio.bytes),


### PR DESCRIPTION
## Objective

Tighten the platform/core seam by typing `replyTo` and inbound `raw` references as `MessageRef` instead of `unknown`.

Closes:

## Problem

- `replyTo` and `InboundMessage.raw` were typed as `unknown`, which made it easy to accidentally pass the wrong platform object across the seam and reduced type safety for future platforms.

## Solution

- `src/core/messaging-adapter.ts`: `sendText(..., { replyTo?: MessageRef })`
- `src/core/platform-messenger.ts`: `sendTextWithRef` + `sendAudio` take `replyTo?: MessageRef`
- `src/core/inbound-message.ts`: `raw: MessageRef`
- `src/core/process-group-message.ts`: `replyTo?: MessageRef`
- Platform adapters update their signatures and continue to cast internally (WhatsApp uses `WAMessage` quoting).

## User-Facing Impact

- None (type-level refactor only).

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (type-only change)

## Risk and Rollback

- Risk level: low
- Primary risk: a platform adapter could incorrectly cast `replyTo` at runtime; tests + TS should catch most wiring issues
- Rollback approach: revert this commit (interfaces revert cleanly)

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [ ] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `src/core/messaging-adapter.ts`
2. `src/core/platform-messenger.ts`