### PR TITLE
docs: update version examples to 0.1.2

### DIFF
--- a/.github/workflows/release-native-binaries.yml
+++ b/.github/workflows/release-native-binaries.yml
@@ -7,10 +7,10 @@ on:
   workflow_dispatch:
     inputs:
       git_ref:
-        description: 'Git ref to build (tag like v0.1.1, branch, or SHA). Default: current ref'
+        description: 'Git ref to build (tag like v0.1.2, branch, or SHA). Default: current ref'
         required: false
       release_tag:
-        description: 'Release tag to publish assets to (e.g., v0.1.1). Required for manual reruns from branches.'
+        description: 'Release tag to publish assets to (e.g., v0.1.2). Required for manual reruns from branches.'
         required: false
 
 permissions:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,8 @@
 # docker-compose.prod.yml — Garbanzo (production override)
 #
 # Usage:
-#   APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
-#   APP_VERSION=0.1.1 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#   APP_VERSION=0.1.2 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+#   APP_VERSION=0.1.2 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 #
 # Purpose:
 # - Disables local image builds so production always runs a tagged release image.
@@ -10,7 +10,7 @@
 services:
   garbanzo:
     # Fail fast if APP_VERSION isn't provided.
-    image: ghcr.io/jjhickman/garbanzo:${APP_VERSION:?APP_VERSION is required (e.g. 0.1.1)}
+    image: ghcr.io/jjhickman/garbanzo:${APP_VERSION:?APP_VERSION is required (e.g. 0.1.2)}
 
     # Ensure the tagged image is pulled even if present locally.
     pull_policy: always


### PR DESCRIPTION
## Objective

Update version example strings in release-related docs/config to point at the current `0.1.2` release.

Closes:

## Problem

- A few operator-facing examples still referenced `0.1.1` even though `0.1.2` is the current release.

## Solution

- `docker-compose.prod.yml`: bump example `APP_VERSION` and the fail-fast message to `0.1.2`.
- `.github/workflows/release-native-binaries.yml`: update manual dispatch input descriptions to use `v0.1.2` in examples.

## User-Facing Impact

- Clearer copy/paste deploy instructions for operators.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs-only change)

## Risk and Rollback

- Risk level: low
- Primary risk: none (string-only)
- Rollback approach: revert commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `docker-compose.prod.yml`
2. `.github/workflows/release-native-binaries.yml`