### PR TITLE
refactor: use MessageRef for replyTo plumbing

### DIFF
--- a/src/core/process-group-message.ts
+++ b/src/core/process-group-message.ts
@@ -175,7 +175,7 @@ async function handleFeedbackCommand(params: {
   senderId: string;
   ownerId: string;
   query: string;
-  replyTo?: unknown;
+  replyTo?: MessageRef;
 }): Promise<void> {
   const { messenger, chatId, senderId, ownerId, query, replyTo } = params;
 
@@ -236,7 +236,7 @@ async function handlePollCommand(params: {
   chatId: string;
   senderId: string;
   featureQuery: string;
-  replyTo?: unknown;
+  replyTo?: MessageRef;
 }): Promise<void> {
   const { messenger, chatId, senderId, featureQuery, replyTo } = params;
 
@@ -262,7 +262,7 @@ async function handleCharacterCommand(params: {
   chatId: string;
   ownerId: string;
   featureQuery: string;
-  replyTo?: unknown;
+  replyTo?: MessageRef;
 }): Promise<void> {
   const { messenger, chatId, ownerId, featureQuery, replyTo } = params;
 
@@ -307,7 +307,7 @@ async function handleVoiceFeature(params: {
   chatId: string;
   featureQuery: string;
   quotedText?: string;
-  replyTo?: unknown;
+  replyTo?: MessageRef;
 }): Promise<void> {
   const { messenger, chatId, featureQuery, quotedText, replyTo } = params;
 

--- a/src/platforms/slack/inbound.ts
+++ b/src/platforms/slack/inbound.ts
@@ -1,4 +1,5 @@
 import type { InboundMessage } from '../../core/inbound-message.js';
+import type { MessageRef } from '../../core/message-ref.js';
 
 /**
  * Slack inbound message (normalized).
@@ -8,5 +9,5 @@ import type { InboundMessage } from '../../core/inbound-message.js';
  */
 export interface SlackInbound extends InboundMessage {
   platform: 'slack';
-  raw: unknown;
+  raw: MessageRef;
 }


### PR DESCRIPTION
## Objective

Make `replyTo` and normalized inbound `raw` refs consistently use `MessageRef` throughout the codebase.

Closes:

## Problem

- A few helper functions still typed `replyTo` as `unknown` even though the platform/core seam now uses `MessageRef` explicitly.
- Slack inbound normalization still typed `raw` as `unknown`, which diverged from the `InboundMessage` contract.

## Solution

- `src/core/process-group-message.ts`: change internal helper param types from `replyTo?: unknown` to `replyTo?: MessageRef`.
- `src/platforms/slack/inbound.ts`: type `raw` as `MessageRef`.

## User-Facing Impact

- None (type-level refactor only).

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (type-only change)

## Risk and Rollback

- Risk level: low
- Primary risk: none (no runtime behavior change)
- Rollback approach: revert commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [ ] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `src/core/process-group-message.ts`
2. `src/platforms/slack/inbound.ts`