### PR TITLE
docs: clarify GitHub Release creation timing

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -37,6 +37,10 @@ git push origin main --follow-tags
 
 4. GitHub Actions publish release artifacts:
 
+Notes:
+
+- The GitHub Release page is created/updated by the release workflows (not by a manual `gh release create`). It may take a few minutes after pushing the tag for the Release to appear and for assets to attach.
+
 - `ghcr.io/jjhickman/garbanzo:vX.Y.Z`
 - `ghcr.io/jjhickman/garbanzo:X.Y.Z`
 - `ghcr.io/jjhickman/garbanzo:latest` (only for non-prerelease tags)


### PR DESCRIPTION
## Objective

Clarify in `docs/RELEASES.md` when the GitHub Release page is created/updated during a tag-based release.

Closes:

## Problem

- It can look like a tag push "did nothing" because the GitHub Release page and assets may not appear until the release workflows complete.
- This can lead to unnecessary manual `gh release create` steps.

## Solution

- Add a short note to `docs/RELEASES.md` explaining that the Release page is created/updated by CI and may take a few minutes after pushing the tag.

## User-Facing Impact

- Clearer release expectations for operators.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs-only)

## Risk and Rollback

- Risk level: low
- Primary risk: none
- Rollback approach: revert commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `docs/RELEASES.md`