### PR TITLE
refactor: define PollPayload shape

### DIFF
--- a/src/core/poll-payload.ts
+++ b/src/core/poll-payload.ts
@@ -1,7 +1,17 @@
 /**
- * Opaque poll payload.
+ * Cross-platform poll payload.
  *
- * Each platform has its own poll API and payload shape.
- * Core treats this as an opaque value.
+ * This matches the subset of WhatsApp/Baileys poll fields we rely on today.
+ * Platforms that don't support native polls can emulate the poll UI.
  */
-export type PollPayload = unknown;
+export interface PollPayload {
+  name: string;
+  values: string[];
+
+  /**
+   * WhatsApp semantics:
+   * - 1 = single-select
+   * - 0 = unlimited selections
+   */
+  selectableCount: number;
+}

--- a/tests/core-group-parity.test.ts
+++ b/tests/core-group-parity.test.ts
@@ -2,6 +2,7 @@ import type { WAMessage } from '@whiskeysockets/baileys';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PlatformMessenger } from '../src/core/platform-messenger.js';
+import type { PollPayload } from '../src/core/poll-payload.js';
 
 function setupMocks() {
   const isFeatureEnabled = vi.fn((_jid: string, feature: string) => feature !== 'poll');
@@ -145,7 +146,7 @@ describe('Core group processor parity (WhatsApp)', () => {
         coreCalls.push({ type: 'textRef', to, payload: text });
         return { key: { id: 'sent2', remoteJid: to } };
       },
-      async sendPoll(to: string, poll: unknown): Promise<void> {
+      async sendPoll(to: string, poll: PollPayload): Promise<void> {
         coreCalls.push({ type: 'poll', to, payload: poll });
       },
       async sendDocument(): Promise<unknown> {
@@ -212,7 +213,7 @@ describe('Core group processor parity (WhatsApp)', () => {
         coreCalls.push({ type: 'textRef', to, payload: t });
         return { key: { id: 'sent2', remoteJid: to } };
       },
-      async sendPoll(to: string, poll: unknown): Promise<void> {
+      async sendPoll(to: string, poll: PollPayload): Promise<void> {
         coreCalls.push({ type: 'poll', to, payload: poll });
       },
       async sendDocument(): Promise<unknown> {


### PR DESCRIPTION
## Objective

Replace the opaque `PollPayload = unknown` with a small typed interface that matches the poll fields Garbanzo uses.

Closes:

## Problem

- Poll payloads were typed as `unknown`, which reduced type safety across the core/platform seam.
- We already have a stable poll shape (`name`, `values`, `selectableCount`) produced by `src/features/polls.ts`.

## Solution

- `src/core/poll-payload.ts`: define `PollPayload` interface with `name`, `values`, `selectableCount`.
- Update parity test messenger mocks to accept the new type.

## User-Facing Impact

- None (type-level refactor only).

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (type-only)

## Risk and Rollback

- Risk level: low
- Primary risk: none
- Rollback approach: revert commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [ ] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `src/core/poll-payload.ts`
2. `tests/core-group-parity.test.ts`