### PR TITLE
feat: add thread semantics to Slack demo outbox

### DIFF
--- a/src/platforms/slack/adapter.ts
+++ b/src/platforms/slack/adapter.ts
@@ -15,6 +15,14 @@ export interface SlackDemoOutboxEntry {
   payload: unknown;
 }
 
+function getThreadIdFromReplyTo(replyTo: MessageRef | undefined): string | null {
+  if (!replyTo) return null;
+  if (replyTo.platform !== 'slack') return null;
+  if (!replyTo.ref || typeof replyTo.ref !== 'object') return null;
+  const r = replyTo.ref as Record<string, unknown>;
+  return typeof r.threadId === 'string' ? r.threadId : null;
+}
+
 export function createSlackAdapter(): PlatformMessenger {
   const err = () => new Error('Slack platform is not implemented');
 
@@ -72,7 +80,11 @@ export function createSlackDemoAdapter(outbox: SlackDemoOutboxEntry[]): Platform
       outbox.push({
         type: 'text',
         chatId,
-        payload: { text, replyTo: options?.replyTo ?? null },
+        payload: {
+          text,
+          replyToId: options?.replyTo?.id ?? null,
+          threadId: getThreadIdFromReplyTo(options?.replyTo),
+        },
       });
     },
 
@@ -89,7 +101,12 @@ export function createSlackDemoAdapter(outbox: SlackDemoOutboxEntry[]): Platform
       outbox.push({
         type: 'text',
         chatId,
-        payload: { text, replyTo: options?.replyTo ?? null, ref },
+        payload: {
+          text,
+          replyToId: options?.replyTo?.id ?? null,
+          threadId: getThreadIdFromReplyTo(options?.replyTo),
+          ref,
+        },
       });
       return ref;
     },
@@ -108,7 +125,13 @@ export function createSlackDemoAdapter(outbox: SlackDemoOutboxEntry[]): Platform
       outbox.push({
         type: 'audio',
         chatId,
-        payload: { mimetype: audio.mimetype, ptt: audio.ptt ?? false, bytesLength: audio.bytes.length, replyTo: options?.replyTo ?? null },
+        payload: {
+          mimetype: audio.mimetype,
+          ptt: audio.ptt ?? false,
+          bytesLength: audio.bytes.length,
+          replyToId: options?.replyTo?.id ?? null,
+          threadId: getThreadIdFromReplyTo(options?.replyTo),
+        },
       });
     },
 

--- a/src/platforms/slack/processor.ts
+++ b/src/platforms/slack/processor.ts
@@ -26,6 +26,9 @@ const SlackDemoMessageSchema = z.object({
   text: z.string().default(''),
   isGroupChat: z.coerce.boolean().default(true),
   groupName: z.string().optional(),
+
+  // demo-only; used to simulate Slack thread replies
+  threadId: z.string().min(1).optional(),
 });
 
 export type SlackDemoMessage = z.infer<typeof SlackDemoMessageSchema>;
@@ -43,7 +46,15 @@ export function normalizeSlackDemoInbound(message: SlackDemoMessage): SlackInbou
     timestampMs: Date.now(),
     text: message.text,
     hasVisualMedia: false,
-    raw: createMessageRef({ platform: 'slack', chatId: message.chatId, id: messageId, ref: message }),
+    raw: createMessageRef({
+      platform: 'slack',
+      chatId: message.chatId,
+      id: messageId,
+      ref: {
+        kind: 'slack-demo-inbound',
+        threadId: message.threadId ?? null,
+      },
+    }),
   };
 }
 

--- a/tests/slack-demo.test.ts
+++ b/tests/slack-demo.test.ts
@@ -21,8 +21,12 @@ describe('Slack demo runtime', () => {
     const first = outbox[0];
     expect(first.type).toBe('text');
 
-    const payload = first.payload as { text?: unknown };
+    const payload = first.payload as { text?: unknown; replyToId?: unknown; threadId?: unknown };
     expect(typeof payload.text).toBe('string');
     expect(String(payload.text)).toContain('Garbanzo Bean');
+
+    // Demo adapter should treat responses as replies to the inbound message.
+    expect(payload.replyToId).toBe(inbound.raw.id);
+    expect(payload.threadId).toBe(null);
   });
 });


### PR DESCRIPTION
## Objective

Make the Slack demo runtime output easier to reason about by adding basic reply/thread semantics to outbox entries.

Closes:

## Problem

- The Slack demo runtime is useful for exercising the core pipeline, but outgoing messages didn’t clearly indicate what they were replying to.
- Without a stable `replyToId`/`threadId`, it’s hard to visually confirm "threaded" behavior in a Slack-like environment.

## Solution

- `src/platforms/slack/processor.ts`:
  - Extend demo inbound schema with optional `threadId`.
  - Store a minimal inbound ref payload (instead of the full inbound object) so adapters can propagate `threadId`.
- `src/platforms/slack/adapter.ts`:
  - Outbox text/audio entries now include:
    - `replyToId` (the inbound message id)
    - `threadId` (propagated from inbound ref)
- `tests/slack-demo.test.ts`:
  - Assert the first response includes `replyToId === inbound.raw.id` and `threadId === null`.

## User-Facing Impact

- None for production; Slack demo is local-only.
- Developer UX improvement: easier to validate "reply" and "thread" semantics from HTTP output.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- POSTed a demo message and confirmed outbox payload includes `replyToId`.

## Risk and Rollback

- Risk level: low
- Primary risk: none (demo-only)
- Rollback approach: revert commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [ ] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `src/platforms/slack/adapter.ts`
2. `src/platforms/slack/processor.ts`