### PR TITLE
test: cover whatsapp deleteMessage behavior

### DIFF
--- a/tests/whatsapp-adapter.test.ts
+++ b/tests/whatsapp-adapter.test.ts
@@ -35,6 +35,25 @@ describe('WhatsApp adapter', () => {
     expect(quoted.message).toEqual(inbound.message);
   });
 
+  it('deletes messages by key using minimal MessageRef', async () => {
+    const sendMessage = vi.fn(async () => ({ key: { id: 'sent1', remoteJid: 'c1' } }));
+    const sock = { sendMessage };
+
+    const adapter = createWhatsAppAdapter(sock as never);
+
+    const inbound = {
+      key: { id: 'm1', remoteJid: 'c1', fromMe: true },
+      message: { conversation: 'hi' },
+    } as unknown as WAMessage;
+
+    const ref = createWhatsAppInboundMessageRef('c1', inbound);
+
+    await adapter.deleteMessage('c1', ref);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith('c1', { delete: inbound.key });
+  });
+
   it('ignores non-whatsapp MessageRefs for quoting and deletion', async () => {
     const sendMessage = vi.fn(async () => ({ key: { id: 'sent1', remoteJid: 'c1' } }));
     const sock = { sendMessage };


### PR DESCRIPTION
## Objective

Add explicit test coverage for WhatsApp `deleteMessage` behavior using the new minimal WhatsApp `MessageRef` representation.

Closes:

## Problem

- We added a minimal WhatsApp `MessageRef` ref payload and adapter helpers (`getDeleteKey`), but deletion behavior was not covered by unit tests.

## Solution

- Extend `tests/whatsapp-adapter.test.ts` with a case asserting that `deleteMessage` calls `sock.sendMessage(chatId, { delete: key })` when given a WhatsApp `MessageRef`.

## User-Facing Impact

- None.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (unit test)

## Risk and Rollback

- Risk level: low
- Primary risk: none
- Rollback approach: revert commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed
- [x] Performance/cost implications reviewed (AI routes, API calls)
- [x] Open Dependabot PRs reviewed (or PR includes `allow-open-dependabot` label + justification)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [ ] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `tests/whatsapp-adapter.test.ts`