### PR TITLE
chore: add log monitoring helpers

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -268,7 +268,7 @@ Research and adopt established, free, trustworthy tools for automated security. 
 6. [x] **Rate limiting on health endpoint** — basic per-IP rate limiting added to `/health`.
 7. [x] **Credential rotation workflow** — monthly GitHub Action reminder (`credential-rotation-reminder.yml`) + local helper for rotating Actions secrets from env (`npm run rotate:gh-secrets`).
 8. [x] **Release automation + version metadata** — tag-driven GHCR/native publishing workflows + version injection into release notes / Docker runtime (`APP_VERSION`, `GARBANZO_VERSION`) + dry-run release validator (`npm run release:plan`).
-7. [ ] **Log monitoring/alerting** — evaluate lightweight solutions (e.g., Logwatch, simple Pino log grep script) to surface error spikes or unusual patterns without a full observability stack.
+9. [x] **Log monitoring/alerting** — added lightweight log scan helpers (`npm run logs:scan`, `npm run logs:journal`) to surface error spikes without a full observability stack.
 
 ### Gate
 - [x] No file in `src/` exceeds 350 lines (largest: `character/class-race-data.ts` at 338)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -172,6 +172,13 @@ chmod +x .git/hooks/pre-commit
 - Docker release workflow scans the published GHCR image for `CRITICAL,HIGH` vulnerabilities (OS + library)
 - Scan is currently non-blocking (report-only) to avoid interrupting releases; report is attached as a workflow artifact
 
+## Log Monitoring Helpers
+
+**Added:** 2026-02-16 — lightweight, local-only scripts (no new deps)
+
+- `npm run logs:scan -- <path>` parses Pino JSON logs and summarizes WARN/ERROR/FATAL counts + top messages
+- `npm run logs:journal -- --unit garbanzo.service --since "24 hours ago"` prints recent systemd user logs (if `journalctl` exists)
+
 ## Runtime Hardening Updates
 
 **Added:** 2026-02-14 (Phase 7.8 partial)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "gh:switch:author": "bash scripts/gh-workflow.sh switch-author",
     "rotate:gh-secrets": "bash scripts/rotate-gh-secrets.sh",
     "release:plan": "node scripts/release-plan.mjs",
+    "logs:scan": "node scripts/log-scan.mjs",
+    "logs:journal": "bash scripts/journal-scan.sh",
     "chime:ready": "tsx scripts/chime.ts ready",
     "chime:error": "tsx scripts/chime.ts error",
     "chime:test": "tsx scripts/chime.ts test"

--- a/scripts/journal-scan.sh
+++ b/scripts/journal-scan.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# Lightweight journal scanner for Garbanzo.
+#
+# Usage:
+#   bash scripts/journal-scan.sh [--unit <unit>] [--since <since>] [--grep <pattern>]
+#
+# Examples:
+#   bash scripts/journal-scan.sh --unit garbanzo.service --since "24 hours ago"
+#   bash scripts/journal-scan.sh --unit garbanzo.service --since "1 hour ago" --grep "ERR|FATAL"
+
+UNIT="garbanzo.service"
+SINCE="24 hours ago"
+GREP_PATTERN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --unit)
+      UNIT="${2:-}"
+      shift 2
+      ;;
+    --since)
+      SINCE="${2:-}"
+      shift 2
+      ;;
+    --grep)
+      GREP_PATTERN="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: bash scripts/journal-scan.sh [--unit <unit>] [--since <since>] [--grep <pattern>]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v journalctl >/dev/null 2>&1; then
+  echo "journalctl not found on this system." >&2
+  exit 2
+fi
+
+CMD=(journalctl --no-pager --user -u "$UNIT" --since "$SINCE")
+
+if [[ -n "$GREP_PATTERN" ]]; then
+  "${CMD[@]}" | grep -En "$GREP_PATTERN" || true
+else
+  "${CMD[@]}"
+fi

--- a/scripts/log-scan.mjs
+++ b/scripts/log-scan.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/*
+  Lightweight log scanner for Garbanzo (Pino JSON logs).
+
+  Usage:
+    node scripts/log-scan.mjs /path/to/log.jsonl
+    node scripts/log-scan.mjs /path/to/log.jsonl --min-level warn --top 15
+
+  Notes:
+  - Expects one JSON object per line (Pino default).
+  - Skips non-JSON lines safely.
+*/
+
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+function usage(exitCode = 1) {
+  // Intentionally plain text (CLI tool output).
+  // eslint-disable-next-line no-console
+  console.log(`Usage: node scripts/log-scan.mjs <logfile> [--min-level <info|warn|error|fatal>] [--top <N>]
+
+Examples:
+  node scripts/log-scan.mjs ./logs/garbanzo.log
+  node scripts/log-scan.mjs ./logs/garbanzo.log --min-level error --top 20
+
+Tip: if you run via npm, pass args after --
+  npm run logs:scan -- ./logs/garbanzo.log --min-level warn
+`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const out = { file: null, minLevel: 'warn', top: 10 };
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a) continue;
+
+    if (a === '-h' || a === '--help') usage(0);
+
+    if (a === '--min-level') {
+      out.minLevel = argv[i + 1] ?? '';
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--min-level=')) {
+      out.minLevel = a.split('=')[1] ?? '';
+      continue;
+    }
+
+    if (a === '--top') {
+      out.top = Number(argv[i + 1] ?? '');
+      i++;
+      continue;
+    }
+
+    if (a.startsWith('--top=')) {
+      out.top = Number(a.split('=')[1] ?? '');
+      continue;
+    }
+
+    if (a.startsWith('-')) {
+      // Unknown flag
+      usage(1);
+    }
+
+    if (!out.file) out.file = a;
+  }
+
+  if (!out.file) usage(1);
+  if (!Number.isFinite(out.top) || out.top <= 0) out.top = 10;
+
+  return out;
+}
+
+const LEVELS = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+};
+
+function resolveMinLevel(name) {
+  const key = String(name ?? '').trim().toLowerCase();
+  const v = LEVELS[key];
+  if (!v) return null;
+  return v;
+}
+
+function bestMessage(obj) {
+  const msg = obj?.msg ?? obj?.message;
+  if (typeof msg === 'string' && msg.trim()) return msg.trim();
+
+  const err = obj?.err;
+  const errMsg = err?.message;
+  if (typeof errMsg === 'string' && errMsg.trim()) return `err: ${errMsg.trim()}`;
+
+  const errType = err?.type;
+  if (typeof errType === 'string' && errType.trim()) return `errType: ${errType.trim()}`;
+
+  return '(no msg)';
+}
+
+function bestWhen(obj) {
+  // Pino typically has `time` as epoch milliseconds.
+  const t = obj?.time;
+  if (typeof t === 'number' && Number.isFinite(t)) {
+    try {
+      return new Date(t).toISOString();
+    } catch {
+      return null;
+    }
+  }
+
+  // Some logs might include ISO strings.
+  const ts = obj?.timestamp;
+  if (typeof ts === 'string' && ts.trim()) return ts.trim();
+
+  return null;
+}
+
+async function main() {
+  const { file, minLevel, top } = parseArgs(process.argv.slice(2));
+  const min = resolveMinLevel(minLevel);
+  if (!min) usage(1);
+
+  if (!fs.existsSync(file)) {
+    // eslint-disable-next-line no-console
+    console.error(`File not found: ${file}`);
+    process.exit(2);
+  }
+
+  const stream = fs.createReadStream(file, { encoding: 'utf8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  let totalLines = 0;
+  let parsed = 0;
+  let skipped = 0;
+  let matched = 0;
+
+  const levelCounts = new Map();
+  const msgCounts = new Map();
+  const samples = [];
+
+  for await (const line of rl) {
+    totalLines++;
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let obj;
+    try {
+      obj = JSON.parse(trimmed);
+      parsed++;
+    } catch {
+      skipped++;
+      continue;
+    }
+
+    const lvl = obj?.level;
+    if (typeof lvl !== 'number') continue;
+    if (lvl < min) continue;
+
+    matched++;
+
+    const levelKey = String(lvl);
+    levelCounts.set(levelKey, (levelCounts.get(levelKey) ?? 0) + 1);
+
+    const msg = bestMessage(obj);
+    msgCounts.set(msg, (msgCounts.get(msg) ?? 0) + 1);
+
+    if (samples.length < 5) {
+      samples.push({
+        when: bestWhen(obj),
+        level: lvl,
+        msg,
+      });
+    }
+  }
+
+  const sortedMsgs = [...msgCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, top);
+
+  // eslint-disable-next-line no-console
+  console.log(`Log scan results: ${file}`);
+  // eslint-disable-next-line no-console
+  console.log(`- Lines: ${totalLines}, parsed JSON: ${parsed}, skipped: ${skipped}`);
+  // eslint-disable-next-line no-console
+  console.log(`- Matched level >= ${min} (${minLevel}): ${matched}`);
+
+  // eslint-disable-next-line no-console
+  console.log('\nLevel counts (numeric):');
+  for (const [k, v] of [...levelCounts.entries()].sort((a, b) => Number(b[0]) - Number(a[0]))) {
+    // eslint-disable-next-line no-console
+    console.log(`- ${k}: ${v}`);
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`\nTop ${sortedMsgs.length} messages:`);
+  for (const [m, c] of sortedMsgs) {
+    // eslint-disable-next-line no-console
+    console.log(`- ${c}x ${m}`);
+  }
+
+  if (samples.length) {
+    // eslint-disable-next-line no-console
+    console.log('\nSample entries:');
+    for (const s of samples) {
+      const when = s.when ? `${s.when} ` : '';
+      // eslint-disable-next-line no-console
+      console.log(`- ${when}level=${s.level} ${s.msg}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Objective

Add lightweight, local-only log monitoring helpers to surface warning/error spikes without requiring a full observability stack.

Closes:

## Problem

- Phase 7.8 called out log monitoring/alerting as a reliability/security hardening item, but we lacked any simple tooling to summarize Pino JSON logs or recent systemd logs.

## Solution

- Add a small JSONL scanner for Pino logs:
  - `scripts/log-scan.mjs`
  - wired via `npm run logs:scan`
- Add a systemd journal helper for user services:
  - `scripts/journal-scan.sh`
  - wired via `npm run logs:journal`
- Update docs to reflect the new helpers and mark the ROADMAP item complete:
  - `docs/SECURITY.md`
  - `docs/ROADMAP.md`

## User-Facing Impact

- Operators/devs can quickly summarize WARN/ERROR/FATAL patterns from a log file.
- Operators can quickly inspect recent `journalctl --user` logs for the Garbanzo unit.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (scripts + docs only)

## Risk and Rollback

- Risk level: low
- Primary risk: none (new scripts only; no runtime behavior change)
- Rollback approach: revert this commit and remove the npm scripts

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (adds optional tooling only)
- [x] Performance/cost implications reviewed (no runtime impact)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `scripts/log-scan.mjs` JSON parsing robustness (skip non-JSON lines, output summaries)
2. `scripts/journal-scan.sh` safe defaults and portability