### PR TITLE
test: cover ops helper scripts

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -191,7 +191,7 @@
 
 ### 7.1 — Split oversized files (convention: max ~300 lines) ✅
 
-All oversized files have been split. `npm run check` passes after every split — 446 tests, 0 errors.
+All oversized files have been split. `npm run check` passes cleanly after each split.
 
 | File | Was | Now | Extracted To |
 |------|----:|----:|-------------|
@@ -215,7 +215,7 @@ Audited all exports across `src/`. Found 28 exports that were never imported ext
 | Un-exported internal types | 10 | `Complexity`, `CategoryConfig`, `ModerationRule`, `InjectionCheck`, `SanitizeResult`, `SpellcastingInfo`, `PDFResult`, `MessageContent`, `MessageHandler`, `CharacterArgs`, `FeedbackResult`, `MediaContent` |
 | Un-exported internal functions | 9 | `buildUserContent`, `checkMessageOpenAI`, `fetchUrlContent`, `getYouTubeMetadata`, `transcribeYouTube`, `sendDigest`, `ABILITY_DISPLAY` |
 
-All 446 tests pass. Typecheck clean. Lint: 0 errors, 52 warnings (reduced).
+Test suite passes. Typecheck clean. Lint remains clean.
 
 ### 7.3 — Consolidate AI clients ✅
 
@@ -240,7 +240,7 @@ Completed as part of 7.1 file splits:
 3. [x] Added integration tests for link processing (mocked fetch + yt-dlp + YouTube transcript path)
 4. [x] Increased branch coverage for `handlers.ts` edge cases (helper extraction, upsert/wiring branches)
 5. [x] Added snapshot tests for formatted outputs (`help`, `profiles`, `memory`)
-6. [x] Test suite increased to 12 files / 446 tests
+6. [x] Test suite increased significantly (currently 16 files / 463 tests)
 
 ### 7.6 — Error handling audit ✅
 
@@ -272,7 +272,7 @@ Research and adopt established, free, trustworthy tools for automated security. 
 
 ### Gate
 - [x] No file in `src/` exceeds 350 lines (largest: `character/class-race-data.ts` at 338)
-- [x] All 446+ tests still pass after refactoring
+- [x] All tests still pass after refactoring
 - [x] `npm run check` clean (0 errors, warnings stable or reduced)
 - [x] Every exported function has a JSDoc comment
 - [x] No `any` types in `src/`

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+function runNodeScript(scriptPath: string, args: string[] = []): string {
+  return execFileSync('node', [scriptPath, ...args], {
+    encoding: 'utf8',
+    cwd: process.cwd(),
+  });
+}
+
+function runBashScript(scriptPath: string, args: string[] = []): string {
+  return execFileSync('bash', [scriptPath, ...args], {
+    encoding: 'utf8',
+    cwd: process.cwd(),
+  });
+}
+
+describe('ops scripts', () => {
+  const root = process.cwd();
+  const logScanPath = join(root, 'scripts/log-scan.mjs');
+  const journalScanPath = join(root, 'scripts/journal-scan.sh');
+  const lynisPath = join(root, 'scripts/host/lynis-audit.sh');
+  const fail2banPath = join(root, 'scripts/host/fail2ban-bootstrap.sh');
+
+  it('log-scan shows usage with --help', () => {
+    const out = runNodeScript(logScanPath, ['--help']);
+    expect(out).toContain('Usage: node scripts/log-scan.mjs');
+  });
+
+  it('log-scan summarizes warn/error entries from JSON logs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'garbanzo-log-scan-'));
+    const file = join(dir, 'app.log');
+
+    const lines = [
+      JSON.stringify({ level: 30, msg: 'info message' }),
+      JSON.stringify({ level: 40, msg: 'warn message', time: 1700000000000 }),
+      JSON.stringify({ level: 50, msg: 'error message' }),
+      JSON.stringify({ level: 50, err: { message: 'boom' } }),
+      'not-json',
+    ];
+
+    writeFileSync(file, `${lines.join('\n')}\n`, 'utf8');
+
+    try {
+      const out = runNodeScript(logScanPath, [file, '--min-level', 'warn', '--top', '5']);
+
+      expect(out).toContain('Log scan results:');
+      expect(out.toLowerCase()).toContain('matched level >= 40');
+      expect(out.toLowerCase()).toContain('skipped: 1');
+      expect(out).toContain('warn message');
+      expect(out).toContain('error message');
+      expect(out).toContain('err: boom');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('journal-scan shows usage with --help', () => {
+    const out = runBashScript(journalScanPath, ['--help']);
+    expect(out).toContain('Usage: bash scripts/journal-scan.sh');
+  });
+
+  it('host hardening scripts show usage with --help', () => {
+    const lynisOut = runBashScript(lynisPath, ['--help']);
+    const fail2banOut = runBashScript(fail2banPath, ['--help']);
+
+    expect(lynisOut).toContain('Usage: bash scripts/host/lynis-audit.sh');
+    expect(fail2banOut).toContain('Usage: bash scripts/host/fail2ban-bootstrap.sh');
+  });
+});


### PR DESCRIPTION
## Objective

Add coverage for the new ops helper scripts and refresh stale ROADMAP test-count wording.

Closes:

## Problem

- We added several operations scripts (`logs:*`, `host:*`) but had no automated test coverage for basic CLI behavior.
- ROADMAP test-count references were stale (older file/test counts).

## Solution

- Add `tests/scripts.test.ts` to validate:
  - `scripts/log-scan.mjs --help`
  - `scripts/log-scan.mjs` summary behavior on a sample JSONL log
  - `scripts/journal-scan.sh --help`
  - `scripts/host/lynis-audit.sh --help`
  - `scripts/host/fail2ban-bootstrap.sh --help`
- Refresh stale wording/counts in `docs/ROADMAP.md` to match the current test suite.

## User-Facing Impact

- No runtime behavior changes.
- Better regression protection for ops tooling and more accurate roadmap context.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (automated tests + docs only)

## Risk and Rollback

- Risk level: low
- Primary risk: minimal (test/docs-only changes)
- Rollback approach: revert this commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `tests/scripts.test.ts` process invocation assertions and temporary-file handling
2. `docs/ROADMAP.md` count/wording updates for correctness