### PR TITLE
chore: improve host helper sudo messaging

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -187,6 +187,7 @@ chmod +x .git/hooks/pre-commit
 - Run on Terra:
   - `npm run host:lynis`
   - If not installed yet: `npm run host:lynis -- --install`
+- Requires sudo (script now reports clearly when no interactive TTY is available)
 - Output is captured to `data/host-audits/` (gitignored)
 
 ## Intrusion Prevention (fail2ban)
@@ -198,6 +199,7 @@ chmod +x .git/hooks/pre-commit
 - Apply (installs + writes `/etc/fail2ban/jail.d/garbanzo-sshd.local` + enables service):
   - `npm run host:fail2ban -- --apply`
   - Optional allowlist: `npm run host:fail2ban -- --apply --ignoreip "127.0.0.1/8 ::1 100.64.0.0/10 192.168.50.0/24"`
+- Requires sudo (script now reports clearly when no interactive TTY is available)
 
 ## Runtime Hardening Updates
 

--- a/scripts/host/fail2ban-bootstrap.sh
+++ b/scripts/host/fail2ban-bootstrap.sh
@@ -19,6 +19,22 @@ FINDTIME="10m"
 BANTIME="1h"
 BACKEND="systemd"
 
+ensure_sudo() {
+  if sudo -n true >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [[ -t 0 ]]; then
+    echo "Sudo privileges are required; prompting for password..."
+    sudo -v
+    return 0
+  fi
+
+  echo "Sudo privileges are required, but no interactive TTY is available." >&2
+  echo "Run this command in an interactive shell, then retry." >&2
+  exit 3
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --apply)
@@ -84,6 +100,7 @@ if ! command -v apt-get >/dev/null 2>&1; then
   exit 2
 fi
 
+ensure_sudo
 sudo apt-get update
 sudo apt-get install -y fail2ban
 

--- a/scripts/host/lynis-audit.sh
+++ b/scripts/host/lynis-audit.sh
@@ -16,6 +16,22 @@ set -euo pipefail
 
 INSTALL=false
 
+ensure_sudo() {
+  if sudo -n true >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [[ -t 0 ]]; then
+    echo "Sudo privileges are required; prompting for password..."
+    sudo -v
+    return 0
+  fi
+
+  echo "Sudo privileges are required, but no interactive TTY is available." >&2
+  echo "Run this command in an interactive shell, then retry." >&2
+  exit 3
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --install)
@@ -46,6 +62,7 @@ if ! command -v lynis >/dev/null 2>&1; then
     exit 2
   fi
 
+  ensure_sudo
   sudo apt-get update
   sudo apt-get install -y lynis
 fi
@@ -60,6 +77,7 @@ OUT="data/host-audits/lynis-${STAMP}.txt"
   echo "=== Lynis audit started: $(date -Is) ==="
   echo "Command: sudo lynis audit system"
   echo
+  ensure_sudo
   sudo lynis audit system --quick --no-colors
   echo
   echo "=== Lynis audit finished: $(date -Is) ==="


### PR DESCRIPTION
## Objective

Improve operator experience for host hardening helpers when sudo is required in non-interactive environments.

Closes:

## Problem

- Running host helper scripts from non-interactive shells can fail with cryptic sudo errors (`a terminal is required to read the password`).
- This makes it less clear how to proceed on real hosts.

## Solution

- Add a shared `ensure_sudo` guard in both host helper scripts:
  - `scripts/host/lynis-audit.sh`
  - `scripts/host/fail2ban-bootstrap.sh`
- Behavior:
  - If passwordless sudo is available, continue silently
  - If interactive TTY is available, prompt via `sudo -v`
  - If no TTY, print a clear message and exit with guidance
- Update security docs to note the improved non-interactive sudo messaging:
  - `docs/SECURITY.md`

## User-Facing Impact

- Clearer operator feedback when running host hardening commands from CI/non-interactive shells.
- No runtime bot behavior changes.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (existing `tests/scripts.test.ts` still passes)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- Confirmed in this environment that `npm run host:lynis -- --install` now fails due to sudo requirement (non-interactive); script is now explicit about this condition.

## Risk and Rollback

- Risk level: low
- Primary risk: none (shell-script UX only)
- Rollback approach: revert this commit

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. `ensure_sudo` behavior for interactive vs non-interactive shells
2. Call sites in both host scripts to ensure sudo checks happen before privileged operations