### PR TITLE
docs: update unreleased changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to Garbanzo are documented here.
 
 ## [Unreleased]
 
-- (no entries yet)
+### Added
+
+- Docker release workflow now includes a report-only Trivy image scan artifact (`trivy-image-report`) for published GHCR images.
+- Lightweight operations helpers added for log and host hardening tasks:
+  - `npm run logs:scan` (Pino JSON log summarizer)
+  - `npm run logs:journal` (systemd user journal helper)
+  - `npm run host:lynis` (Lynis audit helper)
+  - `npm run host:fail2ban` (fail2ban SSH jail bootstrap helper)
+- Added `tests/scripts.test.ts` to cover core CLI behavior for the new operations scripts.
+
+### Changed
+
+- `npm run check` now includes dependency vulnerability scanning via `npm audit --audit-level=high`.
+- Host hardening helper scripts now provide clearer sudo messaging in non-interactive shells.
+- ROADMAP test-suite references were refreshed to align with current suite size.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 


### PR DESCRIPTION
## Objective

Keep `CHANGELOG.md` current by replacing the placeholder Unreleased section with the latest security/ops hardening work merged since `v0.1.5`.

Closes:

## Problem

- `CHANGELOG.md` still showed "(no entries yet)" under Unreleased despite multiple merged changes (dependency audit in `check`, Trivy scan workflow, log/host helper scripts, script tests).

## Solution

- Update `CHANGELOG.md` Unreleased section with Added/Changed entries that reflect recent merged work.

## User-Facing Impact

- Operators and contributors can quickly see what changed since the last tag.
- No runtime behavior changes.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs-only update)

## Risk and Rollback

- Risk level: low
- Primary risk: changelog wording drift if future entries are not maintained
- Rollback approach: edit/revert changelog entry

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (changelog updated)

## Reviewer Focus Areas

1. Ensure Unreleased bullets accurately map to merged PRs #97-#102
2. Ensure wording stays factual and non-duplicative with tagged sections