### PR TITLE
chore: prep v0.1.6 release

### DIFF
--- a/.github/workflows/release-native-binaries.yml
+++ b/.github/workflows/release-native-binaries.yml
@@ -7,10 +7,10 @@ on:
   workflow_dispatch:
     inputs:
       git_ref:
-        description: 'Git ref to build (tag like v0.1.5, branch, or SHA). Default: current ref'
+        description: 'Git ref to build (tag like v0.1.6, branch, or SHA). Default: current ref'
         required: false
       release_tag:
-        description: 'Release tag to publish assets to (e.g., v0.1.5). Required for manual reruns from branches.'
+        description: 'Release tag to publish assets to (e.g., v0.1.6). Required for manual reruns from branches.'
         required: false
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Garbanzo are documented here.
 
 ## [Unreleased]
 
+- (no entries yet)
+
+> Note: older changelog sections include internal phase milestones that predate the current tagged release series.
+
+## [0.1.6] — 2026-02-16
+
 ### Added
 
 - Docker release workflow now includes a report-only Trivy image scan artifact (`trivy-image-report`) for published GHCR images.
@@ -19,8 +25,6 @@ All notable changes to Garbanzo are documented here.
 - `npm run check` now includes dependency vulnerability scanning via `npm audit --audit-level=high`.
 - Host hardening helper scripts now provide clearer sudo messaging in non-interactive shells.
 - ROADMAP test-suite references were refreshed to align with current suite size.
-
-> Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 
 ## [0.1.5] — 2026-02-16
 

--- a/README.md
+++ b/README.md
@@ -454,15 +454,15 @@ By default, `docker compose up -d` runs the published `latest` image.
 To deploy a specific release image:
 
 ```bash
-APP_VERSION=0.1.5 docker compose pull garbanzo
-APP_VERSION=0.1.5 docker compose up -d
+APP_VERSION=0.1.6 docker compose pull garbanzo
+APP_VERSION=0.1.6 docker compose up -d
 ```
 
 Recommended (production) — pin a version and force pulls (prevents accidentally running a stale cached image):
 
 ```bash
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 
 Local development (build from source):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,8 @@
 # docker-compose.prod.yml — Garbanzo (production override)
 #
 # Usage:
-#   APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
-#   APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#   APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+#   APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 #
 # Purpose:
 # - Disables local image builds so production always runs a tagged release image.
@@ -10,7 +10,7 @@
 services:
   garbanzo:
     # Fail fast if APP_VERSION isn't provided.
-    image: ghcr.io/jjhickman/garbanzo:${APP_VERSION:?APP_VERSION is required (e.g. 0.1.5)}
+    image: ghcr.io/jjhickman/garbanzo:${APP_VERSION:?APP_VERSION is required (e.g. 0.1.6)}
 
     # Ensure the tagged image is pulled even if present locally.
     pull_policy: always

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -59,8 +59,8 @@ cd garbanzo-bot
 cp .env.example .env
 # edit .env and config/groups.json
 
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
 docker compose logs -f garbanzo
 ```

--- a/docs/DOCKERHUB_OVERVIEW.md
+++ b/docs/DOCKERHUB_OVERVIEW.md
@@ -21,8 +21,8 @@ cp .env.example .env
 3) Run a pinned release:
 
 ```bash
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 
 Health check:
@@ -46,9 +46,9 @@ This repo publishes both GHCR and Docker Hub tags.
 - `latest`
   - Most recent stable release
   - Only published for non-prerelease versions
-- `0.1.5`
+- `0.1.6`
   - Semver tag without the leading `v`
-- `v0.1.5`
+- `v0.1.6`
   - Git tag style (kept for convenience)
 
 All tags are multi-arch where available:

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -93,15 +93,15 @@ Notes:
 Set `APP_VERSION` in your `.env` before deploy, then pull and restart:
 
 ```bash
-APP_VERSION=0.1.5 docker compose pull garbanzo
-APP_VERSION=0.1.5 docker compose up -d
+APP_VERSION=0.1.6 docker compose pull garbanzo
+APP_VERSION=0.1.6 docker compose up -d
 ```
 
 Recommended (production) — use `docker-compose.prod.yml` to disable local builds:
 
 ```bash
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 
 `docker-compose.prod.yml` also forces pulls so you don't accidentally run a stale cached image.

--- a/docs/SETUP_EXAMPLES.md
+++ b/docs/SETUP_EXAMPLES.md
@@ -76,6 +76,6 @@ curl http://127.0.0.1:3001/health
 Deploy a specific release image tag (recommended):
 
 ```bash
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
-APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -65,7 +65,7 @@ Public subnet (default VPC; easiest to start):
 cd infra/cdk
 
 cdk deploy \
-  -c appVersion=0.1.5 \
+  -c appVersion=0.1.6 \
   -c envParamName=/garbanzo/prod/env \
   -c groupsParamName=/garbanzo/prod/groups_json
 ```
@@ -75,7 +75,7 @@ Hardened (private subnets + NAT; no public IP; access via SSM):
 ```bash
 cdk deploy \
   -c networkMode=private \
-  -c appVersion=0.1.5 \
+  -c appVersion=0.1.6 \
   -c envParamName=/garbanzo/prod/env \
   -c groupsParamName=/garbanzo/prod/groups_json
 ```
@@ -87,7 +87,7 @@ Optionally restrict health endpoint (only useful if you have VPC connectivity to
 ```bash
 cdk deploy \
   -c allowedHealthCidr=203.0.113.4/32 \
-  -c appVersion=0.1.5 \
+  -c appVersion=0.1.6 \
   -c envParamName=/garbanzo/prod/env \
   -c groupsParamName=/garbanzo/prod/groups_json
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbanzo",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbanzo",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbanzo",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Garbanzo Bean — WhatsApp community bot for a Boston-area meetup group",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Objective

Prepare the repository for `v0.1.6` by bumping version metadata, rolling Unreleased changelog entries into a tagged section, and refreshing release/deploy examples.

Closes:

## Problem

- `main` contains merged security/ops hardening changes since `v0.1.5`, but package/docs/changelog were not yet aligned for the next tag.
- A trivia-routing test depended on a live network call and intermittently timed out.

## Solution

- Bump version to `0.1.6`:
  - `package.json`
  - `package-lock.json`
- Move Unreleased entries into `## [0.1.6] — 2026-02-16` and reset Unreleased placeholder:
  - `CHANGELOG.md`
- Update release/deploy examples from `0.1.5` to `0.1.6`:
  - `README.md`
  - `docs/RELEASES.md`
  - `docs/SETUP_EXAMPLES.md`
  - `docs/DOCKERHUB_OVERVIEW.md`
  - `docs/AWS.md`
  - `docker-compose.prod.yml`
  - `infra/cdk/README.md`
  - `.github/workflows/release-native-binaries.yml` (manual dispatch example text)
- Stabilize routing test by mocking trivia API fetch for category routing:
  - `tests/routing.test.ts`

## User-Facing Impact

- Release/deploy docs now point to `0.1.6` examples.
- CI test reliability improves by removing a network-dependent trivia test path.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- `npm run release:plan` intentionally requires `main`; it should be run after merge when preparing to tag.

## Risk and Rollback

- Risk level: low
- Primary risk: docs/version mismatch if additional changes land before tag
- Rollback approach: revert this PR or adjust version/changelog entries before tagging

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (via `CHANGELOG.md`)

## Reviewer Focus Areas

1. Changelog/version consistency for `0.1.6`
2. Deterministic trivia routing test update (`tests/routing.test.ts`)