### PR TITLE
docs: align release checklist with protected main

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.yml
+++ b/.github/ISSUE_TEMPLATE/release-checklist.yml
@@ -33,8 +33,8 @@ body:
     attributes:
       label: Tag and publish
       options:
-        - label: "Bump version (`npm version patch|minor|major`)"
-        - label: "Push commit + tags (`git push origin main --follow-tags`)"
+        - label: "Bump version (`npm version patch|minor|major --no-git-tag-version`)"
+        - label: "Merge version PR into `main`, then push release tag (`git push origin vX.Y.Z`)"
         - label: Confirm `Release Docker Image` workflow success
         - label: Confirm `Release Native Binaries` workflow success
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -256,7 +256,7 @@ Completed as part of 7.1 file splits:
 3. [x] Document multimedia pipeline (Whisper, Piper, Claude/OpenAI Vision payloads, yt-dlp, ffmpeg)
 4. [x] Add inline architecture comments in `handlers.ts` explaining routing stages
 
-### 7.8 — Security & environment hardening
+### 7.8 — Security & environment hardening ✅
 
 Research and adopt established, free, trustworthy tools for automated security. Don't hand-roll — use proven open-source solutions.
 


### PR DESCRIPTION
## Objective

Align release checklist instructions with the protected-`main` workflow used by this repo.

Closes:

## Problem

- The release issue template still referenced `git push origin main --follow-tags`, which conflicts with the current protected-branch flow documented in `docs/RELEASES.md`.

## Solution

- Update `.github/ISSUE_TEMPLATE/release-checklist.yml` to reflect:
  - version bump with `--no-git-tag-version`
  - merge version PR into `main`
  - push tag separately (`git push origin vX.Y.Z`)
- Mark Phase 7.8 section header complete in ROADMAP for consistency:
  - `docs/ROADMAP.md`

## User-Facing Impact

- Release checklist issues now guide contributors through the correct protected-branch release process.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs/template only)

## Risk and Rollback

- Risk level: low
- Primary risk: none (docs/template update only)
- Rollback approach: revert this PR

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. Release checklist wording now matches actual tag workflow under protected `main`
2. ROADMAP completion heading consistency