### PR TITLE
fix: configure slack demo mode in setup wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to Garbanzo are documented here.
 
 ## [Unreleased]
 
-- (no entries yet)
+### Changed
+
+- Setup wizard now supports Slack demo mode configuration (`--platform=slack --slack-demo=true`) and writes `SLACK_DEMO*` env settings.
+- Setup completion messaging now explicitly clarifies platform status (WhatsApp support, Slack demo local-only, Discord/Teams pending).
+- Added script-level coverage for Slack setup dry-run behavior to keep setup output deterministic and regression-safe.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/docs/SETUP_EXAMPLES.md
+++ b/docs/SETUP_EXAMPLES.md
@@ -63,7 +63,18 @@ npm run setup -- --non-interactive \
   --owner-jid=your_number@s.whatsapp.net
 ```
 
-## 6) After setup
+## 6) Slack demo mode (local dev only)
+
+```bash
+npm run setup -- --non-interactive --dry-run \
+  --platform=slack \
+  --slack-demo=true \
+  --providers=openai \
+  --openai-key=$OPENAI_API_KEY \
+  --owner-jid=your_number@s.whatsapp.net
+```
+
+## 7) After setup
 
 Default deployment (Docker Compose):
 

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -22,6 +22,7 @@ describe('ops scripts', () => {
   const root = process.cwd();
   const logScanPath = join(root, 'scripts/log-scan.mjs');
   const journalScanPath = join(root, 'scripts/journal-scan.sh');
+  const setupPath = join(root, 'scripts/setup.mjs');
   const lynisPath = join(root, 'scripts/host/lynis-audit.sh');
   const fail2banPath = join(root, 'scripts/host/fail2ban-bootstrap.sh');
 
@@ -61,6 +62,22 @@ describe('ops scripts', () => {
   it('journal-scan shows usage with --help', () => {
     const out = runBashScript(journalScanPath, ['--help']);
     expect(out).toContain('Usage: bash scripts/journal-scan.sh');
+  });
+
+  it('setup dry-run can configure Slack demo mode', () => {
+    const out = runNodeScript(setupPath, [
+      '--non-interactive',
+      '--dry-run',
+      '--platform=slack',
+      '--slack-demo=true',
+      '--providers=openai',
+      '--openai-key=test_key_setup',
+      '--owner-jid=test_owner@s.whatsapp.net',
+    ]);
+
+    expect(out).toContain('MESSAGING_PLATFORM=slack');
+    expect(out).toContain('SLACK_DEMO=true');
+    expect(out).toContain('Slack demo mode: true');
   });
 
   it('host hardening scripts show usage with --help', () => {


### PR DESCRIPTION
## Objective

Make Slack setup flows produce a runnable local demo configuration instead of a default config that fails at startup.

Closes:

## Problem

- Setup allowed `MESSAGING_PLATFORM=slack`, but generated `.env` omitted `SLACK_DEMO*` settings.
- Since Slack runtime currently requires `SLACK_DEMO=true`, a default Slack setup could fail immediately.
- Setup completion messaging also only warned for Discord, not Teams/Slack demo constraints.

## Solution

- Update `scripts/setup.mjs` to:
  - support `--slack-demo` in non-interactive mode (defaulting to true for Slack platform)
  - prompt for Slack demo mode in interactive Slack flows
  - write `SLACK_DEMO`, `SLACK_DEMO_PORT`, and `SLACK_DEMO_BIND_HOST` into generated `.env`
  - improve end-of-setup platform status messaging (Discord/Teams pending, Slack demo local-only)
  - add a Slack non-interactive example to `--help` output
- Add regression coverage:
  - `tests/scripts.test.ts` now validates Slack setup dry-run output includes `MESSAGING_PLATFORM=slack` + `SLACK_DEMO=true`
- Document usage:
  - `docs/SETUP_EXAMPLES.md` adds Slack demo setup example
  - `CHANGELOG.md` Unreleased updated

## User-Facing Impact

- Slack setup now reliably produces a local-demo-capable configuration.
- Setup output is clearer about which platforms are production-ready vs planned.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- Automated script coverage added for setup dry-run output; no runtime Slack API integration is involved.

## Risk and Rollback

- Risk level: low
- Primary risk: setup wizard behavior change for Slack users (intentional, improves default correctness)
- Rollback approach: revert this PR to restore prior setup behavior

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (via `CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. `scripts/setup.mjs` Slack-mode defaults and generated env fields
2. `tests/scripts.test.ts` setup dry-run regression assertions