### PR TITLE
chore: add release checklist helper script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Garbanzo are documented here.
 - Setup wizard now supports Slack demo mode configuration (`--platform=slack --slack-demo=true`) and writes `SLACK_DEMO*` env settings.
 - Setup completion messaging now explicitly clarifies platform status (WhatsApp support, Slack demo local-only, Discord/Teams pending).
 - Added script-level coverage for Slack setup dry-run behavior to keep setup output deterministic and regression-safe.
+- Added `npm run release:checklist` helper to create and assign release checklist issues using the protected-`main` workflow.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -64,7 +64,11 @@ Notes:
   - `garbanzo-macos-arm64.tar.gz`
   - `garbanzo-windows-x64.zip`
 
-5. Open a release checklist issue from `.github/ISSUE_TEMPLATE/release-checklist.yml` and track deploy verification.
+5. Create a release checklist issue and track deploy verification:
+
+```bash
+npm run release:checklist -- --version=0.1.6
+```
 
 ## Version Injection Behavior
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gh:switch:author": "bash scripts/gh-workflow.sh switch-author",
     "rotate:gh-secrets": "bash scripts/rotate-gh-secrets.sh",
     "release:plan": "node scripts/release-plan.mjs",
+    "release:checklist": "node scripts/release-checklist.mjs",
     "logs:scan": "node scripts/log-scan.mjs",
     "logs:journal": "bash scripts/journal-scan.sh",
     "host:lynis": "bash scripts/host/lynis-audit.sh",

--- a/scripts/release-checklist.mjs
+++ b/scripts/release-checklist.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, '..');
+const PACKAGE_JSON = resolve(PROJECT_ROOT, 'package.json');
+
+function printHelp() {
+  process.stdout.write([
+    'Garbanzo release checklist helper',
+    '',
+    'Usage:',
+    '  npm run release:checklist -- --version=0.1.6',
+    '  npm run release:checklist -- --version=v0.1.6 --assignees=jjhickman,garbanzo-dev',
+    '',
+    'Flags:',
+    '  --version <semver>    Target release version (required; v-prefix optional)',
+    '  --assignees <csv>     Issue assignees (default: jjhickman,garbanzo-dev)',
+    '  --help                Show this help',
+    '',
+    'Behavior:',
+    '  - Ensures release label exists',
+    '  - Creates [release] vX.Y.Z checklist issue',
+    '  - Adds release label and assignees',
+  ].join('\n'));
+}
+
+function parseArgs(argv) {
+  const out = {
+    version: '',
+    assignees: 'jjhickman,garbanzo-dev',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+
+    if (token === '--help' || token === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+
+    if (token === '--version' && argv[i + 1]) {
+      out.version = argv[i + 1];
+      i += 1;
+      continue;
+    }
+
+    if (token.startsWith('--version=')) {
+      out.version = token.slice('--version='.length);
+      continue;
+    }
+
+    if (token === '--assignees' && argv[i + 1]) {
+      out.assignees = argv[i + 1];
+      i += 1;
+      continue;
+    }
+
+    if (token.startsWith('--assignees=')) {
+      out.assignees = token.slice('--assignees='.length);
+      continue;
+    }
+  }
+
+  return out;
+}
+
+function normalizeVersion(value) {
+  const trimmed = String(value || '').trim();
+  return trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+}
+
+function isSemverLike(value) {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(value);
+}
+
+function runGh(args) {
+  return execFileSync('gh', args, {
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function ensureReleaseLabel() {
+  try {
+    runGh(['label', 'create', 'release', '--description', 'Release tracking tasks', '--color', '0E8A16']);
+  } catch (err) {
+    const msg = String(err?.stderr || err?.message || '');
+    if (msg.includes('already exists')) return;
+    throw err;
+  }
+}
+
+function getPackageVersion() {
+  const pkg = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8'));
+  return normalizeVersion(pkg.version || '');
+}
+
+function buildBody(version) {
+  return [
+    '## Version',
+    version,
+    '',
+    '## Pre-release quality gate',
+    '- [ ] `npm run check` passes on local main',
+    '- [ ] Dependabot queue reviewed (`npm run gh:dependabot`)',
+    '- [ ] `CHANGELOG.md` updated for this release',
+    '- [ ] Docs updates complete (`README.md`, `docs/RELEASES.md`, relevant feature docs)',
+    '',
+    '## Tag and publish',
+    '- [ ] Bump version (`npm version patch|minor|major --no-git-tag-version`)',
+    '- [ ] Merge version PR into `main`, then push release tag (`git push origin vX.Y.Z`)',
+    '- [ ] Confirm `Release Docker Image` workflow success',
+    '- [ ] Confirm `Release Native Binaries` workflow success',
+    '',
+    '## Deploy and verify',
+    '- [ ] Deploy image with `APP_VERSION`',
+    '- [ ] Health endpoint responds after deploy',
+    '- [ ] Owner DM `!release` broadcast sent with expected version',
+    '- [ ] Rollback plan prepared/documented',
+    '',
+    '## Release notes / rollout notes',
+    '- ',
+  ].join('\n');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const version = normalizeVersion(args.version || getPackageVersion());
+
+  if (!version || !isSemverLike(version)) {
+    process.stderr.write('❌ Provide a valid --version (example: 0.1.6)\n');
+    process.exit(1);
+  }
+
+  const assignees = String(args.assignees || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  ensureReleaseLabel();
+
+  const ghArgs = [
+    'issue',
+    'create',
+    '--title',
+    `[release] v${version} checklist`,
+    '--label',
+    'release',
+    '--body',
+    buildBody(version),
+  ];
+
+  for (const assignee of assignees) {
+    ghArgs.push('--assignee', assignee);
+  }
+
+  const url = runGh(ghArgs);
+  process.stdout.write(`${url}\n`);
+}
+
+main();

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -23,6 +23,7 @@ describe('ops scripts', () => {
   const logScanPath = join(root, 'scripts/log-scan.mjs');
   const journalScanPath = join(root, 'scripts/journal-scan.sh');
   const setupPath = join(root, 'scripts/setup.mjs');
+  const releaseChecklistPath = join(root, 'scripts/release-checklist.mjs');
   const lynisPath = join(root, 'scripts/host/lynis-audit.sh');
   const fail2banPath = join(root, 'scripts/host/fail2ban-bootstrap.sh');
 
@@ -78,6 +79,12 @@ describe('ops scripts', () => {
     expect(out).toContain('MESSAGING_PLATFORM=slack');
     expect(out).toContain('SLACK_DEMO=true');
     expect(out).toContain('Slack demo mode: true');
+  });
+
+  it('release-checklist script shows usage with --help', () => {
+    const out = runNodeScript(releaseChecklistPath, ['--help']);
+    expect(out).toContain('Garbanzo release checklist helper');
+    expect(out).toContain('npm run release:checklist');
   });
 
   it('host hardening scripts show usage with --help', () => {


### PR DESCRIPTION
## Objective

Reduce release-ops friction by automating release checklist issue creation with correct defaults for this repo's protected-`main` workflow.

Closes:

## Problem

- Creating release checklist issues manually is error-prone (label may be missing, shell quoting can break body text, assignees can be forgotten).
- We already enforce disciplined release flow; this repetitive step should be deterministic.

## Solution

- Add `scripts/release-checklist.mjs` and wire `npm run release:checklist` in `package.json`.
- Script behavior:
  - validates/normalizes target version
  - ensures `release` label exists
  - creates `[release] vX.Y.Z checklist` issue with standard checklist body
  - assigns default owners (`jjhickman`, `garbanzo-dev`) unless overridden
- Update docs and tests:
  - `docs/RELEASES.md` now points to `npm run release:checklist -- --version=...`
  - `tests/scripts.test.ts` adds help-output coverage for the new script
  - `CHANGELOG.md` Unreleased updated

## User-Facing Impact

- Maintainers can create release checklist issues in one command with less room for mistakes.
- No runtime bot behavior changes.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- Existing issue #105 was created/managed during v0.1.6 release workflow; this PR formalizes that process in a script.

## Risk and Rollback

- Risk level: low
- Primary risk: minimal CLI-script maintenance overhead
- Rollback approach: revert this PR and return to manual issue creation

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (`CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. `scripts/release-checklist.mjs` argument handling + safe `gh` invocation
2. Alignment of generated checklist content with `.github/ISSUE_TEMPLATE/release-checklist.yml`