### PR TITLE
docs: refresh release command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ tests/
 - **Storage:** SQLite via better-sqlite3 (WAL mode, auto-vacuum, nightly backups)
 - **Validation:** Zod
 - **Logging:** Pino (structured JSON)
-- **Testing:** Vitest (450+ tests)
+- **Testing:** Vitest (460+ tests)
 - **PDF:** pdf-lib (D&D character sheets)
 
 ## Development
@@ -430,6 +430,7 @@ npm run lint        # ESLint
 npm run check       # Full pre-commit: secrets + typecheck + lint + test
 npm run release:plan # Dry-run release validation before tagging
 # add -- --clean-artifacts to remove local release artifact folders
+npm run release:checklist -- --version=0.1.6 # Open release checklist issue
 npm run build       # Compile to dist/
 npm run start       # Production (from dist/)
 ```

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -67,7 +67,7 @@ Notes:
 5. Create a release checklist issue and track deploy verification:
 
 ```bash
-npm run release:checklist -- --version=0.1.6
+npm run release:checklist -- --version=X.Y.Z
 ```
 
 ## Version Injection Behavior


### PR DESCRIPTION
## Objective

Keep release command docs aligned with current tooling and test-suite scale.

Closes:

## Problem

- README still showed an older test-count range and did not mention the new `release:checklist` helper.
- `docs/RELEASES.md` used a concrete version in the checklist command example where a generic placeholder is clearer.

## Solution

- Update `README.md`:
  - test line from 450+ to 460+
  - add `npm run release:checklist -- --version=0.1.6` to development command examples
- Update `docs/RELEASES.md` checklist command example to `--version=X.Y.Z`

## User-Facing Impact

- Maintainers get more accurate and actionable release command guidance.
- No runtime behavior changes.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs-only)

## Risk and Rollback

- Risk level: low
- Primary risk: none (documentation-only)
- Rollback approach: revert this PR

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. Ensure command examples align with `package.json` scripts and protected-main release flow
2. Ensure placeholder usage (`X.Y.Z`) is consistent in release docs