### PR TITLE
docs: add release rollback playbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.yml
+++ b/.github/ISSUE_TEMPLATE/release-checklist.yml
@@ -46,7 +46,7 @@ body:
         - label: Deploy image with `APP_VERSION`
         - label: Health endpoint responds after deploy
         - label: Owner DM `!release` broadcast sent with expected version
-        - label: Rollback plan prepared/documented
+        - label: "Rollback plan prepared/documented (see docs/RELEASES.md Rollback Playbook)"
 
   - type: textarea
     id: notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Garbanzo are documented here.
 - Setup completion messaging now explicitly clarifies platform status (WhatsApp support, Slack demo local-only, Discord/Teams pending).
 - Added script-level coverage for Slack setup dry-run behavior to keep setup output deterministic and regression-safe.
 - Added `npm run release:checklist` helper to create and assign release checklist issues using the protected-`main` workflow.
+- Added a rollback playbook to `docs/RELEASES.md` and linked it from the release checklist template.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -110,6 +110,27 @@ APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.ym
 
 `docker-compose.prod.yml` also forces pulls so you don't accidentally run a stale cached image.
 
+## Rollback Playbook
+
+If a deploy introduces problems, roll back to the last known-good release tag.
+
+1. Identify the prior healthy version (example: `0.1.5`).
+2. Redeploy with that version:
+
+```bash
+APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.5 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+3. Verify health and readiness:
+
+```bash
+curl -fsS http://127.0.0.1:3001/health
+curl -fsS http://127.0.0.1:3001/health/ready
+```
+
+4. Post rollback notes in the active release checklist issue (what failed, rollback version, follow-up PR/issue links).
+
 ## Manual Workflow Dispatch
 
 You can run workflows manually from Actions:


### PR DESCRIPTION
## Objective

Document a concrete rollback procedure for release deployments and wire that guidance directly into the release checklist template.

Closes:

## Problem

- Release checklist asks for rollback planning, but there was no concise rollback playbook in release docs.
- This made rollback readiness less explicit during release verification.

## Solution

- Add `## Rollback Playbook` section to `docs/RELEASES.md` with concrete commands and verification steps.
- Update `.github/ISSUE_TEMPLATE/release-checklist.yml` rollback checkbox text to point to the new playbook.
- Note the change in `CHANGELOG.md` Unreleased.

## User-Facing Impact

- Maintainers have a clear, copy/paste rollback path during release incidents.
- No runtime behavior changes.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs/template only)

## Risk and Rollback

- Risk level: low
- Primary risk: none (documentation update)
- Rollback approach: revert this PR

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (`CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. Rollback steps in `docs/RELEASES.md` are correct for protected-main + APP_VERSION deploy model
2. Release checklist template points to the new playbook clearly