### PR TITLE
chore: add deploy and verify release helper

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.yml
+++ b/.github/ISSUE_TEMPLATE/release-checklist.yml
@@ -43,7 +43,7 @@ body:
     attributes:
       label: Deploy and verify
       options:
-        - label: Deploy image with `APP_VERSION`
+        - label: "Deploy image with `APP_VERSION` (or `npm run release:deploy:verify` helper)"
         - label: Health endpoint responds after deploy
         - label: Owner DM `!release` broadcast sent with expected version
         - label: "Rollback plan prepared/documented (see docs/RELEASES.md Rollback Playbook)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Garbanzo are documented here.
 - Added script-level coverage for Slack setup dry-run behavior to keep setup output deterministic and regression-safe.
 - Added `npm run release:checklist` helper to create and assign release checklist issues using the protected-`main` workflow.
 - Added a rollback playbook to `docs/RELEASES.md` and linked it from the release checklist template.
+- Added `npm run release:deploy:verify` helper to deploy a target tag, verify health/readiness, and optionally auto-rollback.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ npm run check       # Full pre-commit: secrets + typecheck + lint + test
 npm run release:plan # Dry-run release validation before tagging
 # add -- --clean-artifacts to remove local release artifact folders
 npm run release:checklist -- --version=0.1.6 # Open release checklist issue
+npm run release:deploy:verify -- --version=0.1.6 --rollback-version=0.1.5
 npm run build       # Compile to dist/
 npm run start       # Production (from dist/)
 ```

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -70,6 +70,12 @@ Notes:
 npm run release:checklist -- --version=X.Y.Z
 ```
 
+6. Deploy and verify in one command (optional helper):
+
+```bash
+npm run release:deploy:verify -- --version=X.Y.Z --rollback-version=W.Y.Z
+```
+
 ## Version Injection Behavior
 
 - Docker build uses `APP_VERSION` build arg.
@@ -109,6 +115,12 @@ APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.ym
 ```
 
 `docker-compose.prod.yml` also forces pulls so you don't accidentally run a stale cached image.
+
+Automated deploy+verify helper (same compose defaults, with optional rollback):
+
+```bash
+npm run release:deploy:verify -- --version=0.1.6 --rollback-version=0.1.5
+```
 
 ## Rollback Playbook
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rotate:gh-secrets": "bash scripts/rotate-gh-secrets.sh",
     "release:plan": "node scripts/release-plan.mjs",
     "release:checklist": "node scripts/release-checklist.mjs",
+    "release:deploy:verify": "bash scripts/release-deploy-verify.sh",
     "logs:scan": "node scripts/log-scan.mjs",
     "logs:journal": "bash scripts/journal-scan.sh",
     "host:lynis": "bash scripts/host/lynis-audit.sh",

--- a/scripts/release-deploy-verify.sh
+++ b/scripts/release-deploy-verify.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy a specific Garbanzo release image and verify /health + /health/ready.
+#
+# Usage:
+#   bash scripts/release-deploy-verify.sh --version 0.1.6
+#   bash scripts/release-deploy-verify.sh --version 0.1.6 --rollback-version 0.1.5
+#
+# Notes:
+# - Defaults to docker-compose.yml + docker-compose.prod.yml
+# - Uses APP_VERSION env var for pull/up commands
+
+VERSION=""
+ROLLBACK_VERSION=""
+COMPOSE_FILES="docker-compose.yml,docker-compose.prod.yml"
+SERVICE="garbanzo"
+HEALTH_URL="http://127.0.0.1:3001/health"
+READY_URL="http://127.0.0.1:3001/health/ready"
+RETRIES=30
+SLEEP_SECONDS=2
+DRY_RUN=false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/release-deploy-verify.sh --version <X.Y.Z> [options]
+
+Options:
+  --version <X.Y.Z>            Release version to deploy (required)
+  --rollback-version <X.Y.Z>   Optional fallback version if verification fails
+  --compose-files <csv>        Compose files (default: docker-compose.yml,docker-compose.prod.yml)
+  --service <name>             Compose service name (default: garbanzo)
+  --health-url <url>           Health endpoint (default: http://127.0.0.1:3001/health)
+  --ready-url <url>            Readiness endpoint (default: http://127.0.0.1:3001/health/ready)
+  --retries <n>                Verification attempts (default: 30)
+  --sleep <seconds>            Delay between attempts (default: 2)
+  --dry-run                    Print commands only
+  -h, --help                   Show help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --rollback-version)
+      ROLLBACK_VERSION="${2:-}"
+      shift 2
+      ;;
+    --compose-files)
+      COMPOSE_FILES="${2:-}"
+      shift 2
+      ;;
+    --service)
+      SERVICE="${2:-}"
+      shift 2
+      ;;
+    --health-url)
+      HEALTH_URL="${2:-}"
+      shift 2
+      ;;
+    --ready-url)
+      READY_URL="${2:-}"
+      shift 2
+      ;;
+    --retries)
+      RETRIES="${2:-}"
+      shift 2
+      ;;
+    --sleep)
+      SLEEP_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$VERSION" ]]; then
+  echo "--version is required" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Invalid --version value: $VERSION" >&2
+  exit 1
+fi
+
+if [[ -n "$ROLLBACK_VERSION" ]] && ! [[ "$ROLLBACK_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Invalid --rollback-version value: $ROLLBACK_VERSION" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required but not found in PATH" >&2
+  exit 2
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required but not found in PATH" >&2
+  exit 2
+fi
+
+if ! [[ "$RETRIES" =~ ^[0-9]+$ ]] || [[ "$RETRIES" -lt 1 ]]; then
+  echo "--retries must be a positive integer" >&2
+  exit 1
+fi
+
+if ! [[ "$SLEEP_SECONDS" =~ ^[0-9]+$ ]] || [[ "$SLEEP_SECONDS" -lt 1 ]]; then
+  echo "--sleep must be a positive integer" >&2
+  exit 1
+fi
+
+IFS=',' read -r -a FILE_LIST <<< "$COMPOSE_FILES"
+COMPOSE_CMD=(docker compose)
+
+for file in "${FILE_LIST[@]}"; do
+  trimmed="$(printf '%s' "$file" | xargs)"
+  if [[ -n "$trimmed" ]]; then
+    COMPOSE_CMD+=(-f "$trimmed")
+  fi
+done
+
+run_compose_deploy() {
+  local deploy_version="$1"
+
+  local pull_cmd=("${COMPOSE_CMD[@]}" pull "$SERVICE")
+  local up_cmd=("${COMPOSE_CMD[@]}" up -d "$SERVICE")
+
+  echo "Deploying version $deploy_version"
+  echo "- APP_VERSION=$deploy_version ${pull_cmd[*]}"
+  echo "- APP_VERSION=$deploy_version ${up_cmd[*]}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    return 0
+  fi
+
+  APP_VERSION="$deploy_version" "${pull_cmd[@]}"
+  APP_VERSION="$deploy_version" "${up_cmd[@]}"
+}
+
+verify_endpoints() {
+  local health_ok=false
+  local ready_ok=false
+
+  echo "Verifying endpoints"
+  echo "- health: $HEALTH_URL"
+  echo "- ready:  $READY_URL"
+
+  for ((i = 1; i <= RETRIES; i++)); do
+    if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+      health_ok=true
+    fi
+
+    if curl -fsS "$READY_URL" >/dev/null 2>&1; then
+      ready_ok=true
+    fi
+
+    if [[ "$health_ok" == "true" && "$ready_ok" == "true" ]]; then
+      echo "Verification passed on attempt $i/$RETRIES"
+      return 0
+    fi
+
+    sleep "$SLEEP_SECONDS"
+  done
+
+  echo "Verification failed after $RETRIES attempts" >&2
+  echo "- health_ok=$health_ok" >&2
+  echo "- ready_ok=$ready_ok" >&2
+  return 1
+}
+
+run_compose_deploy "$VERSION"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dry run complete. No changes applied."
+  exit 0
+fi
+
+if verify_endpoints; then
+  echo "Deploy + verify complete for version $VERSION"
+  exit 0
+fi
+
+if [[ -n "$ROLLBACK_VERSION" ]]; then
+  echo "Attempting rollback to version $ROLLBACK_VERSION" >&2
+  run_compose_deploy "$ROLLBACK_VERSION"
+  if verify_endpoints; then
+    echo "Rollback successful to version $ROLLBACK_VERSION" >&2
+  else
+    echo "Rollback verification failed for version $ROLLBACK_VERSION" >&2
+  fi
+fi
+
+exit 1

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -24,6 +24,7 @@ describe('ops scripts', () => {
   const journalScanPath = join(root, 'scripts/journal-scan.sh');
   const setupPath = join(root, 'scripts/setup.mjs');
   const releaseChecklistPath = join(root, 'scripts/release-checklist.mjs');
+  const releaseDeployVerifyPath = join(root, 'scripts/release-deploy-verify.sh');
   const lynisPath = join(root, 'scripts/host/lynis-audit.sh');
   const fail2banPath = join(root, 'scripts/host/fail2ban-bootstrap.sh');
 
@@ -85,6 +86,12 @@ describe('ops scripts', () => {
     const out = runNodeScript(releaseChecklistPath, ['--help']);
     expect(out).toContain('Garbanzo release checklist helper');
     expect(out).toContain('npm run release:checklist');
+  });
+
+  it('release-deploy-verify script shows usage with --help', () => {
+    const out = runBashScript(releaseDeployVerifyPath, ['--help']);
+    expect(out).toContain('bash scripts/release-deploy-verify.sh --version <X.Y.Z>');
+    expect(out).toContain('--rollback-version <X.Y.Z>');
   });
 
   it('host hardening scripts show usage with --help', () => {


### PR DESCRIPTION
## Objective

Automate the remaining high-friction release-verification step: deploy target tag + verify health/readiness, with optional rollback.

Closes:

## Problem

- Release checklist deploy verification still requires several manual commands and ad-hoc retries.
- Rollback handling was documented but not operationalized in a single command path.

## Solution

- Add `scripts/release-deploy-verify.sh` and `npm run release:deploy:verify`.
- Script capabilities:
  - deploy target version with compose pull/up using `APP_VERSION`
  - verify both `/health` and `/health/ready` with retries
  - optional automatic rollback to a provided fallback version on failure
  - supports `--dry-run` and custom compose/service/endpoint flags
- Update release docs and checklist template:
  - `docs/RELEASES.md` includes helper usage
  - `.github/ISSUE_TEMPLATE/release-checklist.yml` points deploy step to helper option
  - `README.md` command examples include helper
  - `CHANGELOG.md` Unreleased updated
- Add script help coverage:
  - `tests/scripts.test.ts`

## User-Facing Impact

- Operators can run a single command for release deploy verification with built-in retry/rollback behavior.
- No runtime bot behavior changes.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- Script behavior validated through help/argument checks in test suite; deployment path remains host-environment specific.

## Risk and Rollback

- Risk level: low
- Primary risk: shell-script assumptions about compose service names/files (mitigated via configurable flags)
- Rollback approach: revert this PR and use manual deploy commands

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed (improves release verification workflow)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (`CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. `scripts/release-deploy-verify.sh` argument validation and rollback branch behavior
2. Doc/template updates match actual helper usage and protected-main workflow