### PR TITLE
fix: accept equals-style deploy helper flags

### DIFF
--- a/scripts/release-deploy-verify.sh
+++ b/scripts/release-deploy-verify.sh
@@ -46,33 +46,65 @@ while [[ $# -gt 0 ]]; do
       VERSION="${2:-}"
       shift 2
       ;;
+    --version=*)
+      VERSION="${1#--version=}"
+      shift
+      ;;
     --rollback-version)
       ROLLBACK_VERSION="${2:-}"
       shift 2
+      ;;
+    --rollback-version=*)
+      ROLLBACK_VERSION="${1#--rollback-version=}"
+      shift
       ;;
     --compose-files)
       COMPOSE_FILES="${2:-}"
       shift 2
       ;;
+    --compose-files=*)
+      COMPOSE_FILES="${1#--compose-files=}"
+      shift
+      ;;
     --service)
       SERVICE="${2:-}"
       shift 2
+      ;;
+    --service=*)
+      SERVICE="${1#--service=}"
+      shift
       ;;
     --health-url)
       HEALTH_URL="${2:-}"
       shift 2
       ;;
+    --health-url=*)
+      HEALTH_URL="${1#--health-url=}"
+      shift
+      ;;
     --ready-url)
       READY_URL="${2:-}"
       shift 2
+      ;;
+    --ready-url=*)
+      READY_URL="${1#--ready-url=}"
+      shift
       ;;
     --retries)
       RETRIES="${2:-}"
       shift 2
       ;;
+    --retries=*)
+      RETRIES="${1#--retries=}"
+      shift
+      ;;
     --sleep)
       SLEEP_SECONDS="${2:-}"
       shift 2
+      ;;
+    --sleep=*)
+      SLEEP_SECONDS="${1#--sleep=}"
+      shift
       ;;
     --dry-run)
       DRY_RUN=true
@@ -106,14 +138,16 @@ if [[ -n "$ROLLBACK_VERSION" ]] && ! [[ "$ROLLBACK_VERSION" =~ ^[0-9]+\.[0-9]+\.
   exit 1
 fi
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "docker is required but not found in PATH" >&2
-  exit 2
-fi
+if [[ "$DRY_RUN" != "true" ]]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required but not found in PATH" >&2
+    exit 2
+  fi
 
-if ! command -v curl >/dev/null 2>&1; then
-  echo "curl is required but not found in PATH" >&2
-  exit 2
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required but not found in PATH" >&2
+    exit 2
+  fi
 fi
 
 if ! [[ "$RETRIES" =~ ^[0-9]+$ ]] || [[ "$RETRIES" -lt 1 ]]; then

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -94,6 +94,17 @@ describe('ops scripts', () => {
     expect(out).toContain('--rollback-version <X.Y.Z>');
   });
 
+  it('release-deploy-verify supports equals-style flags in dry-run mode', () => {
+    const out = runBashScript(releaseDeployVerifyPath, [
+      '--version=0.1.6',
+      '--rollback-version=0.1.5',
+      '--dry-run',
+    ]);
+
+    expect(out).toContain('Deploying version 0.1.6');
+    expect(out).toContain('Dry run complete. No changes applied.');
+  });
+
   it('host hardening scripts show usage with --help', () => {
     const lynisOut = runBashScript(lynisPath, ['--help']);
     const fail2banOut = runBashScript(fail2banPath, ['--help']);


### PR DESCRIPTION
## Objective

Fix immediate usability regression in the new deploy-verify helper so documented flag styles work as expected.

Closes:

## Problem

- `release-deploy-verify.sh` initially only accepted space-separated flags (e.g. `--version 0.1.6`).
- Our docs and common CLI style use equals-form flags (`--version=0.1.6`), which failed with "Unknown arg".

## Solution

- Extend parser in `scripts/release-deploy-verify.sh` to accept both forms for all options:
  - `--flag value`
  - `--flag=value`
- Skip `docker`/`curl` binary checks in `--dry-run` mode so dry-run is environment-agnostic.
- Add regression test in `tests/scripts.test.ts` to verify equals-style flags in dry-run mode.

## User-Facing Impact

- `npm run release:deploy:verify -- --version=0.1.6 --rollback-version=0.1.5 --dry-run` now works.
- Dry-run can be used in environments without Docker installed.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- Confirmed locally: equals-style dry-run invocation now succeeds and prints planned commands.

## Risk and Rollback

- Risk level: low
- Primary risk: none (argument parsing/path checks only)
- Rollback approach: revert this PR

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [ ] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated (already aligned; this fix restores documented behavior)
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. Option parser additions for `--key=value` forms
2. Dry-run dependency check gating (should avoid hard dependency on docker/curl)