### PR TITLE
docs: refresh project status and roadmap references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Garbanzo are documented here.
 - Added `npm run release:checklist` helper to create and assign release checklist issues using the protected-`main` workflow.
 - Added a rollback playbook to `docs/RELEASES.md` and linked it from the release checklist template.
 - Added `npm run release:deploy:verify` helper to deploy a target tag, verify health/readiness, and optionally auto-rollback.
+- `release:deploy:verify` now accepts both `--flag value` and `--flag=value` forms for safer CLI usage in scripts.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 A WhatsApp community bot built with [Baileys](https://github.com/WhiskeySockets/Baileys) and cloud AI routing. Originally built for a 120+ member Boston-area meetup group, designed to be adaptable to any community or locale.
 
+## Current Status
+
+- Production runtime: WhatsApp (Slack local demo mode available for pipeline testing)
+- Latest tagged release: `v0.1.6`
+- Delivery state: Phases 1-7 complete, Phase 8 (platform expansion) queued
+
 ## Why Garbanzo
 
 - Turn busy group chats into actionable community coordination (events, plans, recs, summaries)
@@ -417,7 +423,7 @@ tests/
 - **Storage:** SQLite via better-sqlite3 (WAL mode, auto-vacuum, nightly backups)
 - **Validation:** Zod
 - **Logging:** Pino (structured JSON)
-- **Testing:** Vitest (460+ tests)
+- **Testing:** Vitest (467+ tests)
 - **PDF:** pdf-lib (D&D character sheets)
 
 ## Development
@@ -430,8 +436,12 @@ npm run lint        # ESLint
 npm run check       # Full pre-commit: secrets + typecheck + lint + test
 npm run release:plan # Dry-run release validation before tagging
 # add -- --clean-artifacts to remove local release artifact folders
-npm run release:checklist -- --version=0.1.6 # Open release checklist issue
-npm run release:deploy:verify -- --version=0.1.6 --rollback-version=0.1.5
+npm run release:checklist -- --version=X.Y.Z # Open release checklist issue
+npm run release:deploy:verify -- --version=X.Y.Z --rollback-version=W.Y.Z
+npm run logs:scan -- ./logs/garbanzo.log --min-level warn
+npm run logs:journal -- --unit garbanzo.service --since "24 hours ago"
+npm run host:lynis -- --install
+npm run host:fail2ban -- --apply
 npm run build       # Compile to dist/
 npm run start       # Production (from dist/)
 ```
@@ -638,7 +648,7 @@ Use `bash scripts/rotate-gh-secrets.sh --help` for full options.
 ## Docs
 
 - [PERSONA.md](docs/PERSONA.md) — Bot personality and voice guidelines
-- [ROADMAP.md](docs/ROADMAP.md) — Phased implementation plan (Phases 1-6 complete, Phase 7 in progress)
+- [ROADMAP.md](docs/ROADMAP.md) — Phased implementation plan (Phases 1-7 complete; Phase 8 expansion track queued)
 - [SECURITY.md](docs/SECURITY.md) — Infrastructure security audit + data privacy
 - [INFRASTRUCTURE.md](docs/INFRASTRUCTURE.md) — Hardware and network reference
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — Message flow, AI routing, and multimedia pipeline

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -240,7 +240,7 @@ Completed as part of 7.1 file splits:
 3. [x] Added integration tests for link processing (mocked fetch + yt-dlp + YouTube transcript path)
 4. [x] Increased branch coverage for `handlers.ts` edge cases (helper extraction, upsert/wiring branches)
 5. [x] Added snapshot tests for formatted outputs (`help`, `profiles`, `memory`)
-6. [x] Test suite increased significantly (currently 16 files / 463 tests)
+6. [x] Test suite increased significantly (currently 16 files / 467 tests)
 
 ### 7.6 — Error handling audit ✅
 


### PR DESCRIPTION
## Objective

Align top-level docs with the current post-v0.1.6 state so contributors/operators have accurate status, command, and roadmap references.

Closes:

## Problem

- README still implied Phase 7 was in progress and had stale command/test-count references.
- ROADMAP test-count line lagged behind the current test suite size.
- Unreleased changelog did not mention the latest release-deploy helper CLI behavior update.

## Solution

- Update `README.md` with:
  - explicit current status snapshot
  - current test-count range
  - current ops/release helper commands
  - corrected roadmap status wording
- Update `docs/ROADMAP.md` test suite reference to current count.
- Update `CHANGELOG.md` Unreleased notes for `release:deploy:verify` flag parsing behavior.

## User-Facing Impact

- Documentation is consistent with actual repository/runtime state.
- No runtime behavior changes.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs-only)

## Risk and Rollback

- Risk level: low
- Primary risk: none (docs updates)
- Rollback approach: revert this PR

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (`CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. Ensure status wording reflects current release/phase state
2. Ensure command examples and test-count references are internally consistent