### PR TITLE
feat: add AWS support website stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Garbanzo are documented here.
 - Added a rollback playbook to `docs/RELEASES.md` and linked it from the release checklist template.
 - Added `npm run release:deploy:verify` helper to deploy a target tag, verify health/readiness, and optionally auto-rollback.
 - `release:deploy:verify` now accepts both `--flag value` and `--flag=value` forms for safer CLI usage in scripts.
+- Added an AWS CDK support-site stack (`GarbanzoSiteStack`) to publish `website/` to S3 + CloudFront.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Note: Donations (Sponsors/Patreon/Ko-fi) help fund development but do not grant 
 
 - GitHub Sponsors: https://github.com/sponsors/jjhickman
 - (Optional) Configure Patreon/Ko-fi/custom links in `.env`
+- Optional public support site can be deployed on AWS via `infra/cdk` (`GarbanzoSiteStack`)
 
 Owner-side support messaging:
 

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -85,6 +85,33 @@ curl http://127.0.0.1:3001/health
 
 If you publish port `3001` publicly/within a VPC, restrict it to trusted monitors.
 
+## Revenue Website on AWS (S3 + CloudFront)
+
+To stand up a public support/marketing page quickly, use the website stack in `infra/cdk`.
+
+1. Ensure AWS CLI auth is active (`aws sts get-caller-identity`).
+2. Deploy the site stack:
+
+```bash
+cd infra/cdk
+npm install
+cdk deploy GarbanzoSiteStack \
+  -c deployEc2=false \
+  -c deploySite=true
+```
+
+3. Copy the `WebsiteUrl` output and set it as repo homepage:
+
+```bash
+gh repo edit --homepage "https://<cloudfront-domain>"
+```
+
+4. Update your support links:
+
+- Set `PATREON_URL` in your runtime `.env`
+- Optionally add Patreon handle in `.github/FUNDING.yml`
+- Run owner command `!support broadcast` after links are updated
+
 ## Option: ECS Fargate + EFS (More Portable, More Moving Parts)
 
 If you want this managed path in the future, we recommend doing EC2 first to prove stability, then migrating once you know your steady-state CPU/memory and data retention needs.

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -59,6 +59,8 @@ After deploy, overwrite both parameters with real values using the AWS CLI.
 
 ## Deploy
 
+### Deploy Garbanzo app (EC2)
+
 Public subnet (default VPC; easiest to start):
 
 ```bash
@@ -91,6 +93,25 @@ cdk deploy \
   -c envParamName=/garbanzo/prod/env \
   -c groupsParamName=/garbanzo/prod/groups_json
 ```
+
+## Deploy the support website (S3 + CloudFront)
+
+The same CDK app can deploy a simple static support/marketing site from `website/`.
+
+```bash
+cd infra/cdk
+
+cdk deploy GarbanzoSiteStack \
+  -c deployEc2=false \
+  -c deploySite=true
+```
+
+Optional context:
+
+- `-c siteBucketName=your-unique-bucket-name`
+- `-c sitePriceClass=100|200|all` (default `100`)
+
+After deploy, use the `WebsiteUrl` output as your public landing page URL.
 
 ## QR Linking
 

--- a/infra/cdk/bin/garbanzo.ts
+++ b/infra/cdk/bin/garbanzo.ts
@@ -1,17 +1,39 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { GarbanzoEc2Stack } from '../lib/garbanzo-ec2-stack.js';
+import { GarbanzoSiteStack } from '../lib/garbanzo-site-stack.js';
 
 const app = new cdk.App();
 
-new GarbanzoEc2Stack(app, 'GarbanzoEc2Stack', {
-  /*
-   * Set these via `cdk deploy` context or environment:
-   *
-   *   cdk deploy \
-   *     -c appVersion=0.1.1 \
-   *     -c envParamName=/garbanzo/prod/env \
-   *     -c groupsParamName=/garbanzo/prod/groups_json \
-   *     -c allowedHealthCidr=203.0.113.4/32
-   */
-});
+const deployEc2 = String(app.node.tryGetContext('deployEc2') ?? 'true').toLowerCase() !== 'false';
+const deploySite = String(app.node.tryGetContext('deploySite') ?? 'false').toLowerCase() === 'true';
+
+if (!deployEc2 && !deploySite) {
+  throw new Error('Nothing to deploy: set -c deployEc2=true or -c deploySite=true');
+}
+
+if (deployEc2) {
+  new GarbanzoEc2Stack(app, 'GarbanzoEc2Stack', {
+    /*
+     * Set these via `cdk deploy` context or environment:
+     *
+     *   cdk deploy GarbanzoEc2Stack \
+     *     -c appVersion=0.1.6 \
+     *     -c envParamName=/garbanzo/prod/env \
+     *     -c groupsParamName=/garbanzo/prod/groups_json \
+     *     -c allowedHealthCidr=203.0.113.4/32
+     */
+  });
+}
+
+if (deploySite) {
+  new GarbanzoSiteStack(app, 'GarbanzoSiteStack', {
+    /*
+     * Example:
+     *
+     *   cdk deploy GarbanzoSiteStack \
+     *     -c deployEc2=false \
+     *     -c deploySite=true
+     */
+  });
+}

--- a/infra/cdk/lib/garbanzo-site-stack.ts
+++ b/infra/cdk/lib/garbanzo-site-stack.ts
@@ -1,0 +1,89 @@
+import * as cdk from 'aws-cdk-lib';
+import type { Construct } from 'constructs';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WEBSITE_ASSET_PATH = resolve(__dirname, '../../../website');
+
+function optionalContext(app: cdk.App, key: string): string | undefined {
+  const value = app.node.tryGetContext(key);
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parsePriceClass(value: string | undefined): cloudfront.PriceClass {
+  const normalized = String(value ?? '100').trim();
+  if (normalized === '200') return cloudfront.PriceClass.PRICE_CLASS_200;
+  if (normalized === 'all') return cloudfront.PriceClass.PRICE_CLASS_ALL;
+  return cloudfront.PriceClass.PRICE_CLASS_100;
+}
+
+export class GarbanzoSiteStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const app = this.node.root as cdk.App;
+
+    const bucketName = optionalContext(app, 'siteBucketName');
+    const websiteIndex = optionalContext(app, 'siteIndexDocument') ?? 'index.html';
+    const websiteError = optionalContext(app, 'siteErrorDocument') ?? 'index.html';
+    const priceClass = parsePriceClass(optionalContext(app, 'sitePriceClass'));
+
+    const siteBucket = new s3.Bucket(this, 'SiteBucket', {
+      bucketName,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      versioned: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      autoDeleteObjects: false,
+    });
+
+    const distribution = new cloudfront.Distribution(this, 'SiteDistribution', {
+      defaultRootObject: websiteIndex,
+      priceClass,
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+      },
+      errorResponses: [
+        {
+          httpStatus: 404,
+          responseHttpStatus: 200,
+          responsePagePath: `/${websiteError}`,
+          ttl: cdk.Duration.minutes(5),
+        },
+      ],
+    });
+
+    new s3deploy.BucketDeployment(this, 'SiteDeployment', {
+      destinationBucket: siteBucket,
+      sources: [s3deploy.Source.asset(WEBSITE_ASSET_PATH)],
+      distribution,
+      distributionPaths: ['/*'],
+      prune: true,
+      retainOnDelete: false,
+    });
+
+    new cdk.CfnOutput(this, 'WebsiteUrl', {
+      value: `https://${distribution.distributionDomainName}`,
+      description: 'Public CloudFront URL for the Garbanzo marketing/support site',
+    });
+
+    new cdk.CfnOutput(this, 'DistributionId', {
+      value: distribution.distributionId,
+    });
+
+    new cdk.CfnOutput(this, 'SiteBucketName', {
+      value: siteBucket.bucketName,
+    });
+  }
+}

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Garbanzo</title>
+    <meta
+      name="description"
+      content="Garbanzo is an AI community bot for WhatsApp groups: events, recs, summaries, moderation signals, and owner operations."
+    />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <section class="hero">
+        <h1 id="title">Garbanzo</h1>
+        <p id="tagline"></p>
+        <p id="description"></p>
+        <div class="actions">
+          <a id="ctaPrimary" class="button button-primary" href="#" target="_blank" rel="noreferrer">Support</a>
+          <a id="ctaSecondary" class="button button-secondary" href="#" target="_blank" rel="noreferrer">Repository</a>
+        </div>
+      </section>
+
+      <section class="grid" aria-label="Core strengths">
+        <article class="card">
+          <h3>Community-first workflows</h3>
+          <p>Events, weather, transit, intros, summaries, polls, and owner-ready release broadcasts.</p>
+        </article>
+        <article class="card">
+          <h3>Reliable operations</h3>
+          <p>Health and readiness checks, nightly SQLite backups, release automation, and rollback playbooks.</p>
+        </article>
+        <article class="card">
+          <h3>Cost-aware AI routing</h3>
+          <p>Configurable provider ordering with local-routing options to balance quality, speed, and spend.</p>
+        </article>
+      </section>
+
+      <section class="support" id="support">
+        <h2>Support Garbanzo</h2>
+        <p>If Garbanzo is useful to your community, sponsorship helps fund uptime, development, and support.</p>
+        <ul id="supportLinks"></ul>
+      </section>
+
+      <footer>
+        Built for real communities. Deployed via AWS + Docker. Open source with commercial licensing options.
+      </footer>
+    </main>
+
+    <script>
+      async function loadConfig() {
+        const response = await fetch('./site-config.json', { cache: 'no-store' });
+        if (!response.ok) throw new Error('Failed to load site config');
+        return response.json();
+      }
+
+      function setText(id, value) {
+        const el = document.getElementById(id);
+        if (el && typeof value === 'string' && value.trim()) el.textContent = value;
+      }
+
+      function setLink(id, href, label) {
+        const el = document.getElementById(id);
+        if (!el) return;
+        if (typeof label === 'string' && label.trim()) el.textContent = label;
+        if (typeof href === 'string' && href.trim()) {
+          el.href = href;
+        } else {
+          el.style.display = 'none';
+        }
+      }
+
+      function addSupportLink(list, label, href) {
+        if (!href || !href.trim()) return;
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = href;
+        a.target = '_blank';
+        a.rel = 'noreferrer';
+        a.textContent = label;
+        li.appendChild(a);
+        list.appendChild(li);
+      }
+
+      loadConfig()
+        .then((cfg) => {
+          setText('title', cfg.title);
+          setText('tagline', cfg.tagline);
+          setText('description', cfg.description);
+
+          setLink('ctaPrimary', cfg.githubSponsorsUrl || cfg.patreonUrl, cfg.ctaPrimaryLabel || 'Support');
+          setLink('ctaSecondary', cfg.githubRepoUrl, cfg.ctaSecondaryLabel || 'Repository');
+
+          const list = document.getElementById('supportLinks');
+          addSupportLink(list, 'GitHub Sponsors', cfg.githubSponsorsUrl);
+          addSupportLink(list, 'Patreon', cfg.patreonUrl);
+          addSupportLink(list, 'Ko-fi', cfg.kofiUrl);
+
+          if (!list.children.length) {
+            const li = document.createElement('li');
+            li.textContent = 'Support links are not configured yet.';
+            list.appendChild(li);
+          }
+        })
+        .catch((err) => {
+          const list = document.getElementById('supportLinks');
+          const li = document.createElement('li');
+          li.textContent = `Site config error: ${err instanceof Error ? err.message : String(err)}`;
+          list.appendChild(li);
+        });
+    </script>
+  </body>
+</html>

--- a/website/site-config.json
+++ b/website/site-config.json
@@ -1,0 +1,11 @@
+{
+  "title": "Garbanzo",
+  "tagline": "AI community coordination for real group chats",
+  "description": "Garbanzo helps active communities organize events, answer questions, and keep momentum without burning out moderators.",
+  "githubRepoUrl": "https://github.com/jjhickman/garbanzo-bot",
+  "githubSponsorsUrl": "https://github.com/sponsors/jjhickman",
+  "patreonUrl": "",
+  "kofiUrl": "",
+  "ctaPrimaryLabel": "Sponsor on GitHub",
+  "ctaSecondaryLabel": "View on GitHub"
+}

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,132 @@
+:root {
+  --bg: #f7f8fb;
+  --card: #ffffff;
+  --text: #162033;
+  --muted: #5b667a;
+  --accent: #0f8b8d;
+  --accent-2: #ff6b35;
+  --border: #dbe2ee;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Avenir Next", "Nunito", "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 15% 10%, #e7f7f8 0%, var(--bg) 45%);
+  color: var(--text);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.hero {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: linear-gradient(140deg, #ffffff, #f5fbff 65%);
+  box-shadow: 0 10px 28px rgba(18, 36, 60, 0.08);
+}
+
+.hero h1 {
+  margin: 0;
+  line-height: 1.1;
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.hero p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-block;
+  text-decoration: none;
+  border-radius: 999px;
+  padding: 12px 18px;
+  font-weight: 700;
+  border: 1px solid transparent;
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(15, 139, 141, 0.18);
+}
+
+.button-primary {
+  background: var(--accent);
+  color: white;
+}
+
+.button-secondary {
+  background: white;
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.grid {
+  margin-top: 24px;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  background: var(--card);
+}
+
+.card h3 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.support {
+  margin-top: 24px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  background: #fff;
+}
+
+.support ul {
+  margin: 10px 0 0;
+  padding-left: 18px;
+}
+
+.support li {
+  margin: 8px 0;
+}
+
+.support a {
+  color: var(--accent-2);
+}
+
+footer {
+  color: var(--muted);
+  margin: 24px 0 12px;
+  font-size: 0.95rem;
+}


### PR DESCRIPTION
## Objective

Launch a fast revenue-ready support website path on AWS by adding a deployable static site stack and starter site content.

Closes:

## Problem

- We had support links (Sponsors/Patreon/Ko-fi) in bot config, but no dedicated public landing page hosted on AWS.
- Website setup steps were undocumented, making monetization rollout slower.

## Solution

- Add a new CDK website stack:
  - `infra/cdk/lib/garbanzo-site-stack.ts`
  - S3 (private) + CloudFront + deployment from `website/` assets
- Update CDK entrypoint for conditional stack deployment:
  - `infra/cdk/bin/garbanzo.ts`
  - `deployEc2` / `deploySite` context flags
- Add starter public site content:
  - `website/index.html`
  - `website/styles.css`
  - `website/site-config.json`
- Update docs and support references:
  - `infra/cdk/README.md`
  - `docs/AWS.md`
  - `README.md`
  - `CHANGELOG.md` (Unreleased)

## User-Facing Impact

- Maintainers can deploy a public support website on AWS quickly (`GarbanzoSiteStack`).
- Public page supports sponsor links and gives a clear product overview for potential supporters.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A; infra/docs/static site)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- CDK app builds successfully (`npm install && npm run build` in `infra/cdk`).
- Deployment to AWS will be executed after merge on main and validated via stack outputs.

## Risk and Rollback

- Risk level: low-to-medium
- Primary risk: additional AWS resources (S3 + CloudFront) incur ongoing costs if left running
- Rollback approach: `cdk destroy GarbanzoSiteStack` and remove stack docs

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none for bot runtime)
- [x] Performance/cost implications reviewed (website hosting + CDN costs)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (support/website references)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (`CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. CDK stack defaults and safety (`RemovalPolicy.RETAIN`, OAC, asset deployment)
2. Conditional stack deploy logic in `infra/cdk/bin/garbanzo.ts`
3. Website content/config structure and support-link UX