### PR TITLE
feat: add local discord demo runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,10 @@
 
 # ── Messaging Platform ───────────────────────
 # Supported now: whatsapp
-# Slack is scaffolded; for a local-only demo runtime, set:
-#   MESSAGING_PLATFORM=slack
-#   SLACK_DEMO=true
-# Planned: discord (Phase 8)
+# Local-only demo runtimes (for pipeline testing, no real platform APIs):
+#   MESSAGING_PLATFORM=slack   + SLACK_DEMO=true
+#   MESSAGING_PLATFORM=discord + DISCORD_DEMO=true
+# Planned production runtime: discord (Phase 8)
 MESSAGING_PLATFORM=whatsapp
 
 # ── AI Providers ──────────────────────────────
@@ -84,6 +84,13 @@ METRICS_ENABLED=false
 SLACK_DEMO=false
 SLACK_DEMO_PORT=3002
 SLACK_DEMO_BIND_HOST=127.0.0.1
+
+# ── Discord demo runtime (local dev only) ─────
+# Starts an HTTP server that lets you POST "fake Discord messages" and see
+# what Garbanzo would send back, without needing real Discord APIs.
+DISCORD_DEMO=false
+DISCORD_DEMO_PORT=3003
+DISCORD_DEMO_BIND_HOST=127.0.0.1
 
 # Log level: debug | info | warn | error
 LOG_LEVEL=info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Garbanzo are documented here.
 - Added `npm run release:deploy:verify` helper to deploy a target tag, verify health/readiness, and optionally auto-rollback.
 - `release:deploy:verify` now accepts both `--flag value` and `--flag=value` forms for safer CLI usage in scripts.
 - Added an AWS CDK support-site stack (`GarbanzoSiteStack`) to publish `website/` to S3 + CloudFront.
+- Added local Discord demo runtime scaffolding (`DISCORD_DEMO`) with HTTP simulation and parity tests, mirroring the Slack demo pattern.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ curl -s -X POST http://127.0.0.1:3002/slack/demo \
   -d '{"chatId":"C123","senderId":"U123","text":"@garbanzo !help"}'
 ```
 
+### Discord Demo Mode (optional)
+
+Discord production runtime is not implemented yet, but local demo mode can exercise the core pipeline similarly:
+
+```bash
+# .env
+MESSAGING_PLATFORM=discord
+DISCORD_DEMO=true
+
+npm run dev
+
+# In another terminal
+curl -s -X POST http://127.0.0.1:3003/discord/demo \
+  -H 'content-type: application/json' \
+  -d '{"chatId":"C123","senderId":"U123","text":"@garbanzo !help"}'
+```
+
 ### Automated / Non-Interactive Setup
 
 Use non-interactive mode for reproducible setup in scripts or CI-like environments:

--- a/src/platforms/discord/adapter.ts
+++ b/src/platforms/discord/adapter.ts
@@ -1,0 +1,136 @@
+import type { MessagingAdapter } from '../../core/messaging-adapter.js';
+import { createMessageRef, type MessageRef } from '../../core/message-ref.js';
+import type { PollPayload } from '../../core/poll-payload.js';
+import type { PlatformMessenger, DocumentPayload, AudioPayload } from '../../core/platform-messenger.js';
+
+export interface DiscordDemoOutboxEntry {
+  type: 'text' | 'poll' | 'document' | 'audio' | 'delete';
+  chatId: string;
+  payload: unknown;
+}
+
+function getThreadIdFromReplyTo(replyTo: MessageRef | undefined): string | null {
+  if (!replyTo) return null;
+  if (replyTo.platform !== 'discord') return null;
+  if (!replyTo.ref || typeof replyTo.ref !== 'object') return null;
+  const r = replyTo.ref as Record<string, unknown>;
+  return typeof r.threadId === 'string' ? r.threadId : null;
+}
+
+export function createDiscordAdapter(): PlatformMessenger {
+  const err = () => new Error('Discord platform is not implemented');
+
+  const adapter: PlatformMessenger = {
+    platform: 'discord',
+
+    async sendText(): Promise<void> {
+      throw err();
+    },
+
+    async sendPoll(_chatId: string, _poll: PollPayload): Promise<void> {
+      throw err();
+    },
+
+    async sendTextWithRef(): Promise<MessageRef> {
+      throw err();
+    },
+
+    async sendDocument(_chatId: string, _doc: DocumentPayload): Promise<MessageRef> {
+      throw err();
+    },
+
+    async sendAudio(_chatId: string, _audio: AudioPayload): Promise<void> {
+      throw err();
+    },
+
+    async deleteMessage(): Promise<void> {
+      throw err();
+    },
+  };
+
+  void (adapter satisfies MessagingAdapter);
+
+  return adapter;
+}
+
+export function createDiscordDemoAdapter(outbox: DiscordDemoOutboxEntry[]): PlatformMessenger {
+  const nextRef = (chatId: string, threadId: string | null): MessageRef => createMessageRef({
+    platform: 'discord',
+    chatId,
+    id: `discord-demo-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    ref: { kind: 'discord-demo', threadId },
+  });
+
+  const adapter: PlatformMessenger = {
+    platform: 'discord',
+
+    async sendText(chatId: string, text: string, options?: { replyTo?: MessageRef }): Promise<void> {
+      outbox.push({
+        type: 'text',
+        chatId,
+        payload: {
+          text,
+          replyToId: options?.replyTo?.id ?? null,
+          threadId: getThreadIdFromReplyTo(options?.replyTo),
+        },
+      });
+    },
+
+    async sendPoll(chatId: string, poll: PollPayload): Promise<void> {
+      outbox.push({ type: 'poll', chatId, payload: poll });
+    },
+
+    async sendTextWithRef(chatId: string, text: string, options?: { replyTo?: MessageRef }): Promise<MessageRef> {
+      const threadId = getThreadIdFromReplyTo(options?.replyTo);
+      const ref = nextRef(chatId, threadId);
+      outbox.push({
+        type: 'text',
+        chatId,
+        payload: {
+          text,
+          replyToId: options?.replyTo?.id ?? null,
+          threadId,
+          ref,
+        },
+      });
+      return ref;
+    },
+
+    async sendDocument(chatId: string, doc: DocumentPayload): Promise<MessageRef> {
+      const ref = nextRef(chatId, null);
+      outbox.push({
+        type: 'document',
+        chatId,
+        payload: {
+          fileName: doc.fileName,
+          mimetype: doc.mimetype,
+          bytesLength: doc.bytes.length,
+          ref,
+        },
+      });
+      return ref;
+    },
+
+    async sendAudio(chatId: string, audio: AudioPayload, options?: { replyTo?: MessageRef }): Promise<void> {
+      outbox.push({
+        type: 'audio',
+        chatId,
+        payload: {
+          mimetype: audio.mimetype,
+          ptt: audio.ptt ?? false,
+          bytesLength: audio.bytes.length,
+          replyToId: options?.replyTo?.id ?? null,
+          threadId: getThreadIdFromReplyTo(options?.replyTo),
+        },
+      });
+    },
+
+    async deleteMessage(chatId: string, messageRef: MessageRef): Promise<void> {
+      outbox.push({ type: 'delete', chatId, payload: { messageRef } });
+    },
+  };
+
+  void (adapter satisfies MessagingAdapter);
+
+  return adapter;
+}

--- a/src/platforms/discord/demo-server.ts
+++ b/src/platforms/discord/demo-server.ts
@@ -1,0 +1,102 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+import { logger } from '../../middleware/logger.js';
+import { config } from '../../utils/config.js';
+
+import { createDiscordDemoAdapter, type DiscordDemoOutboxEntry } from './adapter.js';
+import {
+  parseDiscordDemoMessage,
+  normalizeDiscordDemoInbound,
+  processDiscordDemoInbound,
+} from './processor.js';
+
+export function createDiscordDemoServer(params: {
+  host: string;
+  port: number;
+}): ReturnType<typeof createServer> {
+  const server = createServer(async (req, res) => {
+    try {
+      if (!req.url || !req.method) {
+        writeJson(res, 400, { ok: false, error: 'Missing request URL/method' });
+        return;
+      }
+
+      if (req.method === 'GET' && (req.url === '/' || req.url === '/discord/demo')) {
+        writeJson(res, 200, {
+          ok: true,
+          message: 'Discord demo server is running',
+          postTo: '/discord/demo',
+          example: {
+            curl: "curl -s -X POST http://127.0.0.1:" + params.port + "/discord/demo \\\n  -H 'content-type: application/json' \\\n  -d '{\"chatId\":\"C123\",\"senderId\":\"U123\",\"text\":\"@garbanzo !help\"}' | jq",
+          },
+        });
+        return;
+      }
+
+      if (req.method !== 'POST' || req.url !== '/discord/demo') {
+        writeJson(res, 404, { ok: false, error: 'Not found' });
+        return;
+      }
+
+      const body = await readJsonBody(req, 256_000);
+      const msg = parseDiscordDemoMessage(body);
+
+      const inbound = normalizeDiscordDemoInbound(msg);
+      const outbox: DiscordDemoOutboxEntry[] = [];
+      const messenger = createDiscordDemoAdapter(outbox);
+
+      await processDiscordDemoInbound(messenger, inbound, { ownerId: config.OWNER_JID });
+
+      writeJson(res, 200, {
+        ok: true,
+        inbound: {
+          chatId: inbound.chatId,
+          senderId: inbound.senderId,
+          messageId: inbound.messageId,
+          isGroupChat: inbound.isGroupChat,
+        },
+        outbox,
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error({ err, platform: 'discord', path: req.url }, 'Discord demo request failed');
+      writeJson(res, 500, { ok: false, error });
+    }
+  });
+
+  server.listen(params.port, params.host, () => {
+    logger.info({ host: params.host, port: params.port }, 'Discord demo server listening');
+  });
+
+  return server;
+}
+
+async function readJsonBody(req: IncomingMessage, maxBytes: number): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) {
+      throw new Error(`Request body too large (max ${maxBytes} bytes)`);
+    }
+    chunks.push(buf);
+  }
+
+  const raw = Buffer.concat(chunks).toString('utf-8').trim();
+  if (!raw) return {};
+
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error('Invalid JSON body');
+  }
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body, null, 2);
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json; charset=utf-8');
+  res.end(json);
+}

--- a/src/platforms/discord/inbound.ts
+++ b/src/platforms/discord/inbound.ts
@@ -1,0 +1,13 @@
+import type { InboundMessage } from '../../core/inbound-message.js';
+import type { MessageRef } from '../../core/message-ref.js';
+
+/**
+ * Discord inbound message (normalized).
+ *
+ * Discord production runtime is not implemented yet; this type exists for
+ * local demo-mode pipeline validation.
+ */
+export interface DiscordInbound extends InboundMessage {
+  platform: 'discord';
+  raw: MessageRef;
+}

--- a/src/platforms/discord/processor.ts
+++ b/src/platforms/discord/processor.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+
+import { logger } from '../../middleware/logger.js';
+import { processInboundMessage } from '../../core/process-inbound-message.js';
+import { processGroupMessage } from '../../core/process-group-message.js';
+import { getResponse } from '../../core/response-router.js';
+import type { PlatformMessenger } from '../../core/platform-messenger.js';
+import { createMessageRef } from '../../core/message-ref.js';
+import { isFeatureEnabled } from '../../core/groups-config.js';
+
+import type { DiscordInbound } from './inbound.js';
+
+export async function processDiscordEvent(_event: unknown): Promise<void> {
+  logger.fatal({ platform: 'discord' }, 'Discord processor is not implemented yet');
+  throw new Error('Discord processor is not implemented');
+}
+
+const DiscordDemoMessageSchema = z.object({
+  chatId: z.string().min(1),
+  senderId: z.string().min(1),
+  text: z.string().default(''),
+  isGroupChat: z.coerce.boolean().default(true),
+  groupName: z.string().optional(),
+  threadId: z.string().min(1).optional(),
+});
+
+export type DiscordDemoMessage = z.infer<typeof DiscordDemoMessageSchema>;
+
+export function normalizeDiscordDemoInbound(message: DiscordDemoMessage): DiscordInbound {
+  const messageId = `discord-demo-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  return {
+    platform: 'discord',
+    chatId: message.chatId,
+    senderId: message.senderId,
+    messageId,
+    fromSelf: false,
+    isStatusBroadcast: false,
+    isGroupChat: message.isGroupChat,
+    timestampMs: Date.now(),
+    text: message.text,
+    hasVisualMedia: false,
+    raw: createMessageRef({
+      platform: 'discord',
+      chatId: message.chatId,
+      id: messageId,
+      ref: {
+        kind: 'discord-demo-inbound',
+        threadId: message.threadId ?? null,
+      },
+    }),
+  };
+}
+
+export function parseDiscordDemoMessage(input: unknown): DiscordDemoMessage {
+  return DiscordDemoMessageSchema.parse(input);
+}
+
+export async function processDiscordDemoInbound(
+  messenger: PlatformMessenger,
+  inbound: DiscordInbound,
+  env: {
+    ownerId: string;
+  },
+): Promise<void> {
+  await processInboundMessage(messenger, inbound, {
+    isReplyToBot: () => false,
+
+    isAcknowledgment: () => false,
+
+    sendAcknowledgmentReaction: async () => {
+      // no-op for demo
+    },
+
+    handleGroupMessage: async ({ inbound: m, text, hasMedia }) => {
+      const trimmed = text.trim();
+      const mentionMatch = /^@garbanzo\b[:\s]*/i.exec(trimmed);
+      const isBang = trimmed.startsWith('!');
+
+      if (!mentionMatch && !isBang) return;
+
+      let query = trimmed;
+      if (isBang) {
+        query = trimmed;
+      } else if (mentionMatch) {
+        query = trimmed.slice(mentionMatch[0].length).trim();
+      }
+
+      if (!query && !hasMedia) return;
+
+      await processGroupMessage({
+        messenger,
+        chatId: m.chatId,
+        senderId: m.senderId,
+        groupName: 'Discord (demo)',
+        ownerId: env.ownerId,
+        query,
+        isFeatureEnabled,
+        getResponse,
+        messageId: m.messageId,
+        replyTo: m.raw,
+      });
+    },
+
+    handleOwnerDM: async ({ inbound: m, text }) => {
+      const response = await getResponse(
+        text,
+        {
+          groupName: 'Discord DM (demo)',
+          groupJid: m.chatId,
+          senderJid: m.senderId,
+        },
+        isFeatureEnabled,
+      );
+
+      if (response) {
+        await messenger.sendText(m.chatId, response, { replyTo: m.raw });
+      }
+    },
+  }, {
+    ownerId: env.ownerId,
+    isGroupEnabled: () => true,
+    introductionsChatId: null,
+    eventsChatId: null,
+    handleIntroduction: async () => null,
+    handleEventPassive: async () => null,
+  });
+}

--- a/src/platforms/discord/runtime.ts
+++ b/src/platforms/discord/runtime.ts
@@ -1,12 +1,30 @@
 import { logger } from '../../middleware/logger.js';
+import { config } from '../../utils/config.js';
 import type { PlatformRuntime } from '../types.js';
+
+import { createDiscordDemoServer } from './demo-server.js';
 
 export function createDiscordRuntime(): PlatformRuntime {
   return {
     platform: 'discord',
     async start(): Promise<void> {
-      logger.fatal({ platform: 'discord' }, 'Discord runtime is not implemented yet');
-      throw new Error('Discord runtime is not implemented');
+      if (!config.DISCORD_DEMO) {
+        logger.fatal(
+          { platform: 'discord' },
+          'Discord runtime is not implemented (set MESSAGING_PLATFORM=whatsapp, or DISCORD_DEMO=true for local demo mode)',
+        );
+        throw new Error('Discord runtime is not implemented');
+      }
+
+      createDiscordDemoServer({
+        host: config.DISCORD_DEMO_BIND_HOST,
+        port: config.DISCORD_DEMO_PORT,
+      });
+
+      logger.info(
+        { host: config.DISCORD_DEMO_BIND_HOST, port: config.DISCORD_DEMO_PORT },
+        'Discord demo mode started (local dev only)',
+      );
     },
   };
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -62,6 +62,11 @@ const envSchema = z.object({
   SLACK_DEMO_PORT: z.coerce.number().int().min(1).max(65535).default(3002),
   SLACK_DEMO_BIND_HOST: z.string().min(1).default('127.0.0.1'),
 
+  // Discord demo runtime (non-production)
+  DISCORD_DEMO: z.coerce.boolean().default(false),
+  DISCORD_DEMO_PORT: z.coerce.number().int().min(1).max(65535).default(3003),
+  DISCORD_DEMO_BIND_HOST: z.string().min(1).default('127.0.0.1'),
+
   // Database
   DB_DIALECT: z.enum(['sqlite', 'postgres']).default('sqlite'),
   DATABASE_URL: z.string().optional(),

--- a/tests/discord-demo.test.ts
+++ b/tests/discord-demo.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+
+import { createDiscordDemoAdapter } from '../src/platforms/discord/adapter.js';
+import { normalizeDiscordDemoInbound, processDiscordDemoInbound } from '../src/platforms/discord/processor.js';
+
+describe('Discord demo runtime', () => {
+  it('routes @garbanzo !help through the core pipeline', async () => {
+    const outbox: Array<{ type: string; chatId: string; payload: unknown }> = [];
+    const messenger = createDiscordDemoAdapter(outbox);
+
+    const inbound = normalizeDiscordDemoInbound({
+      chatId: 'C123',
+      senderId: 'U123',
+      text: '@garbanzo !help',
+      isGroupChat: true,
+    });
+
+    await processDiscordDemoInbound(messenger, inbound, { ownerId: 'owner@s.whatsapp.net' });
+
+    expect(outbox.length).toBeGreaterThan(0);
+    const first = outbox[0];
+    expect(first.type).toBe('text');
+
+    const payload = first.payload as { text?: unknown; replyToId?: unknown; threadId?: unknown };
+    expect(typeof payload.text).toBe('string');
+    expect(String(payload.text)).toContain('Garbanzo Bean');
+    expect(payload.replyToId).toBe(inbound.raw.id);
+    expect(payload.threadId).toBe(null);
+  });
+
+  it('propagates inbound threadId into the outbox payload', async () => {
+    const outbox: Array<{ type: string; chatId: string; payload: unknown }> = [];
+    const messenger = createDiscordDemoAdapter(outbox);
+
+    const inbound = normalizeDiscordDemoInbound({
+      chatId: 'C123',
+      senderId: 'U123',
+      text: '@garbanzo !help',
+      isGroupChat: true,
+      threadId: 'th-1',
+    });
+
+    await processDiscordDemoInbound(messenger, inbound, { ownerId: 'owner@s.whatsapp.net' });
+
+    expect(outbox.length).toBeGreaterThan(0);
+    const first = outbox[0];
+    expect(first.type).toBe('text');
+
+    const payload = first.payload as { replyToId?: unknown; threadId?: unknown };
+    expect(payload.replyToId).toBe(inbound.raw.id);
+    expect(payload.threadId).toBe('th-1');
+  });
+});


### PR DESCRIPTION
## Objective

Advance Phase 8 platform expansion with a low-risk Discord demo runtime that exercises core pipeline behavior without live Discord APIs.

Closes:

## Problem

- Discord runtime existed only as a hard-fail stub, which blocked parity validation and made it hard to iterate on platform boundaries safely.

## Solution

- Add Discord demo runtime scaffolding mirroring the Slack demo pattern:
  - `src/platforms/discord/adapter.ts`
  - `src/platforms/discord/inbound.ts`
  - `src/platforms/discord/processor.ts`
  - `src/platforms/discord/demo-server.ts`
- Update Discord runtime startup behavior:
  - `src/platforms/discord/runtime.ts`
  - starts local demo server when `DISCORD_DEMO=true`, otherwise keeps hard fail for production runtime
- Add config/env support:
  - `src/utils/config.ts`
  - `.env.example`
- Add parity tests:
  - `tests/discord-demo.test.ts`
- Update docs/changelog:
  - `README.md`
  - `CHANGELOG.md`

## User-Facing Impact

- New local-only Discord demo mode available for development and core-pipeline testing.
- No production Discord API integration yet.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- Covered by automated demo tests and full check pipeline; no external Discord calls involved.

## Risk and Rollback

- Risk level: low
- Primary risk: confusion between demo mode and production readiness (mitigated by explicit config gating/messages)
- Rollback approach: revert this PR

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (`CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. Discord demo parity with Slack demo behavior and core routing boundaries
2. Config gating (`DISCORD_DEMO`) ensures production Discord still fails explicitly