### PR TITLE
feat: add Patreon and custom domain support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,8 @@
 # Keep values in sync with README support section.
 
 github: [jjhickman]
-# patreon: your_patreon_handle
+patreon: garbanzobot
 # ko_fi: your_kofi_handle
 custom:
   - https://github.com/sponsors/jjhickman
+  - https://www.patreon.com/c/garbanzobot

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ data/
 *.log
 .DS_Store
 release/
+infra/cdk/cdk.out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Garbanzo are documented here.
 - `release:deploy:verify` now accepts both `--flag value` and `--flag=value` forms for safer CLI usage in scripts.
 - Added an AWS CDK support-site stack (`GarbanzoSiteStack`) to publish `website/` to S3 + CloudFront.
 - Added local Discord demo runtime scaffolding (`DISCORD_DEMO`) with HTTP simulation and parity tests, mirroring the Slack demo pattern.
+- Added custom-domain support to the AWS support-site stack (`siteDomainName` + `siteHostedZoneId`) and wired Patreon support links into site/repo funding metadata.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/README.md
+++ b/README.md
@@ -596,8 +596,10 @@ If Garbanzo is useful for your community, you can support development and operat
 Note: Donations (Sponsors/Patreon/Ko-fi) help fund development but do not grant a commercial license. For commercial licensing, see `COMMERCIAL_LICENSE.md`.
 
 - GitHub Sponsors: https://github.com/sponsors/jjhickman
-- (Optional) Configure Patreon/Ko-fi/custom links in `.env`
-- Optional public support site can be deployed on AWS via `infra/cdk` (`GarbanzoSiteStack`)
+- Patreon: https://www.patreon.com/c/garbanzobot
+- (Optional) Configure Ko-fi/custom links in `.env`
+- Public support site: https://d1qesoxr778xh2.cloudfront.net (custom domain migration to `garbanzobot.com` in progress)
+- Optional AWS website deployment via `infra/cdk` (`GarbanzoSiteStack`)
 
 Owner-side support messaging:
 

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -90,14 +90,16 @@ If you publish port `3001` publicly/within a VPC, restrict it to trusted monitor
 To stand up a public support/marketing page quickly, use the website stack in `infra/cdk`.
 
 1. Ensure AWS CLI auth is active (`aws sts get-caller-identity`).
-2. Deploy the site stack:
+2. Deploy the site stack (with optional custom domain):
 
 ```bash
 cd infra/cdk
 npm install
 cdk deploy GarbanzoSiteStack \
   -c deployEc2=false \
-  -c deploySite=true
+  -c deploySite=true \
+  -c siteDomainName=garbanzobot.com \
+  -c siteHostedZoneId=Z065585312QAJF1P6J0UL
 ```
 
 3. Copy the `WebsiteUrl` output and set it as repo homepage:
@@ -108,8 +110,8 @@ gh repo edit --homepage "https://<cloudfront-domain>"
 
 4. Update your support links:
 
-- Set `PATREON_URL` in your runtime `.env`
-- Optionally add Patreon handle in `.github/FUNDING.yml`
+- Set `PATREON_URL` in your runtime `.env` (e.g., `https://www.patreon.com/c/garbanzobot`)
+- Keep Patreon handle in `.github/FUNDING.yml` in sync
 - Run owner command `!support broadcast` after links are updated
 
 ## Option: ECS Fargate + EFS (More Portable, More Moving Parts)

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -110,6 +110,18 @@ Optional context:
 
 - `-c siteBucketName=your-unique-bucket-name`
 - `-c sitePriceClass=100|200|all` (default `100`)
+- `-c siteDomainName=garbanzobot.com`
+- `-c siteHostedZoneId=<route53-hosted-zone-id>`
+
+Example with custom domain + Route 53 aliases:
+
+```bash
+cdk deploy GarbanzoSiteStack \
+  -c deployEc2=false \
+  -c deploySite=true \
+  -c siteDomainName=garbanzobot.com \
+  -c siteHostedZoneId=Z065585312QAJF1P6J0UL
+```
 
 After deploy, use the `WebsiteUrl` output as your public landing page URL.
 

--- a/infra/cdk/lib/garbanzo-site-stack.ts
+++ b/infra/cdk/lib/garbanzo-site-stack.ts
@@ -2,6 +2,9 @@ import * as cdk from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as targets from 'aws-cdk-lib/aws-route53-targets';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import { dirname, resolve } from 'node:path';
@@ -34,6 +37,33 @@ export class GarbanzoSiteStack extends cdk.Stack {
     const websiteIndex = optionalContext(app, 'siteIndexDocument') ?? 'index.html';
     const websiteError = optionalContext(app, 'siteErrorDocument') ?? 'index.html';
     const priceClass = parsePriceClass(optionalContext(app, 'sitePriceClass'));
+    const siteDomainName = optionalContext(app, 'siteDomainName');
+    const siteHostedZoneId = optionalContext(app, 'siteHostedZoneId');
+
+    const normalizedDomain = siteDomainName?.replace(/\.$/, '');
+
+    let hostedZone: route53.IHostedZone | undefined;
+    let certificate: acm.ICertificate | undefined;
+    let domainNames: string[] | undefined;
+
+    if (normalizedDomain) {
+      if (!siteHostedZoneId) {
+        throw new Error('siteHostedZoneId is required when siteDomainName is set');
+      }
+
+      hostedZone = route53.HostedZone.fromHostedZoneAttributes(this, 'SiteHostedZone', {
+        hostedZoneId: siteHostedZoneId,
+        zoneName: normalizedDomain,
+      });
+
+      certificate = new acm.Certificate(this, 'SiteCertificate', {
+        domainName: normalizedDomain,
+        subjectAlternativeNames: [`www.${normalizedDomain}`],
+        validation: acm.CertificateValidation.fromDns(hostedZone),
+      });
+
+      domainNames = [normalizedDomain, `www.${normalizedDomain}`];
+    }
 
     const siteBucket = new s3.Bucket(this, 'SiteBucket', {
       bucketName,
@@ -48,6 +78,8 @@ export class GarbanzoSiteStack extends cdk.Stack {
     const distribution = new cloudfront.Distribution(this, 'SiteDistribution', {
       defaultRootObject: websiteIndex,
       priceClass,
+      certificate,
+      domainNames,
       defaultBehavior: {
         origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -74,8 +106,13 @@ export class GarbanzoSiteStack extends cdk.Stack {
     });
 
     new cdk.CfnOutput(this, 'WebsiteUrl', {
+      value: normalizedDomain ? `https://${normalizedDomain}` : `https://${distribution.distributionDomainName}`,
+      description: 'Public URL for the Garbanzo marketing/support site',
+    });
+
+    new cdk.CfnOutput(this, 'CloudFrontUrl', {
       value: `https://${distribution.distributionDomainName}`,
-      description: 'Public CloudFront URL for the Garbanzo marketing/support site',
+      description: 'CloudFront domain URL',
     });
 
     new cdk.CfnOutput(this, 'DistributionId', {
@@ -85,5 +122,29 @@ export class GarbanzoSiteStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'SiteBucketName', {
       value: siteBucket.bucketName,
     });
+
+    if (hostedZone && normalizedDomain) {
+      new route53.ARecord(this, 'SiteAliasApexA', {
+        zone: hostedZone,
+        target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
+      });
+
+      new route53.AaaaRecord(this, 'SiteAliasApexAAAA', {
+        zone: hostedZone,
+        target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
+      });
+
+      new route53.ARecord(this, 'SiteAliasWwwA', {
+        zone: hostedZone,
+        recordName: 'www',
+        target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
+      });
+
+      new route53.AaaaRecord(this, 'SiteAliasWwwAAAA', {
+        zone: hostedZone,
+        recordName: 'www',
+        target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
+      });
+    }
   }
 }

--- a/website/index.html
+++ b/website/index.html
@@ -89,7 +89,7 @@
           setText('tagline', cfg.tagline);
           setText('description', cfg.description);
 
-          setLink('ctaPrimary', cfg.githubSponsorsUrl || cfg.patreonUrl, cfg.ctaPrimaryLabel || 'Support');
+          setLink('ctaPrimary', cfg.patreonUrl || cfg.githubSponsorsUrl, cfg.ctaPrimaryLabel || 'Support');
           setLink('ctaSecondary', cfg.githubRepoUrl, cfg.ctaSecondaryLabel || 'Repository');
 
           const list = document.getElementById('supportLinks');

--- a/website/site-config.json
+++ b/website/site-config.json
@@ -4,8 +4,8 @@
   "description": "Garbanzo helps active communities organize events, answer questions, and keep momentum without burning out moderators.",
   "githubRepoUrl": "https://github.com/jjhickman/garbanzo-bot",
   "githubSponsorsUrl": "https://github.com/sponsors/jjhickman",
-  "patreonUrl": "",
+  "patreonUrl": "https://www.patreon.com/c/garbanzobot",
   "kofiUrl": "",
-  "ctaPrimaryLabel": "Sponsor on GitHub",
+  "ctaPrimaryLabel": "Support on Patreon",
   "ctaSecondaryLabel": "View on GitHub"
 }


### PR DESCRIPTION
## Objective

Activate monetization links and prepare the AWS support site for `garbanzobot.com` custom-domain cutover.

Closes:

## Problem

- Patreon link was not wired into repo funding metadata or website config.
- Site stack published only CloudFront URL and did not support Route 53 + ACM custom domain context.
- Generated CDK artifacts (`infra/cdk/cdk.out`) were unignored in repo hygiene.

## Solution

- Wire Patreon links:
  - `.github/FUNDING.yml` adds `patreon: garbanzobot`
  - `website/site-config.json` includes Patreon URL
  - `website/index.html` prefers Patreon as primary CTA when configured
  - `README.md` support section includes Patreon + current site URL
- Add custom domain support to site stack:
  - `infra/cdk/lib/garbanzo-site-stack.ts`
  - optional context `siteDomainName` + `siteHostedZoneId`
  - creates ACM cert (DNS validated) and Route 53 alias records for apex + www
  - outputs both `WebsiteUrl` and `CloudFrontUrl`
- Update docs:
  - `infra/cdk/README.md`
  - `docs/AWS.md`
  - `CHANGELOG.md`
- Repo hygiene:
  - `.gitignore` ignores `infra/cdk/cdk.out/`

## User-Facing Impact

- Support website and GitHub sponsor metadata now expose Patreon.
- Site can be promoted with a first-party custom domain (`garbanzobot.com`) once domain registration completes.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- CDK app builds successfully (`npm run build` in `infra/cdk`).
- Existing CloudFront site serves updated website content.

## Risk and Rollback

- Risk level: low-to-medium
- Primary risk: ACM issuance/custom-domain DNS propagation delays while domain registration is in progress
- Rollback approach: deploy stack without custom-domain context and continue using CloudFront URL

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none for bot runtime)
- [x] Performance/cost implications reviewed (website CDN/storage costs)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (`CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. Custom-domain stack wiring (ACM + Route53 aliases) and context validation
2. Patreon link consistency across FUNDING, website config, and README