### PR TITLE
feat: automate support site deploy workflow

### DIFF
--- a/.github/workflows/deploy-support-site.yml
+++ b/.github/workflows/deploy-support-site.yml
@@ -1,0 +1,159 @@
+name: Deploy Support Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - 'infra/cdk/bin/garbanzo.ts'
+      - 'infra/cdk/lib/garbanzo-site-stack.ts'
+      - 'infra/cdk/package.json'
+      - 'infra/cdk/package-lock.json'
+      - '.github/workflows/deploy-support-site.yml'
+  workflow_dispatch:
+    inputs:
+      siteDomainName:
+        description: 'Optional custom domain (example: garbanzobot.com)'
+        required: false
+      siteHostedZoneId:
+        description: 'Optional Route53 hosted zone ID (required with custom domain)'
+        required: false
+      sitePriceClass:
+        description: 'Optional CloudFront price class: 100, 200, all'
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-support-site
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy GarbanzoSiteStack
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Resolve deployment settings
+        id: settings
+        shell: bash
+        env:
+          INPUT_DOMAIN: ${{ github.event.inputs.siteDomainName }}
+          INPUT_ZONE: ${{ github.event.inputs.siteHostedZoneId }}
+          INPUT_PRICE_CLASS: ${{ github.event.inputs.sitePriceClass }}
+          VAR_DOMAIN: ${{ vars.SITE_DOMAIN_NAME }}
+          VAR_ZONE: ${{ vars.SITE_HOSTED_ZONE_ID }}
+          VAR_PRICE_CLASS: ${{ vars.SITE_PRICE_CLASS }}
+          VAR_REGION: ${{ vars.AWS_REGION }}
+          SECRET_ROLE: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          VAR_ROLE: ${{ vars.AWS_ROLE_TO_ASSUME }}
+        run: |
+          set -euo pipefail
+
+          ROLE="$SECRET_ROLE"
+          if [[ -z "$ROLE" ]]; then
+            ROLE="$VAR_ROLE"
+          fi
+          if [[ -z "$ROLE" ]]; then
+            echo "AWS_ROLE_TO_ASSUME is required (secret or repo variable)." >&2
+            exit 1
+          fi
+
+          REGION="$VAR_REGION"
+          if [[ -z "$REGION" ]]; then
+            REGION="us-east-1"
+          fi
+
+          DOMAIN="$INPUT_DOMAIN"
+          if [[ -z "$DOMAIN" ]]; then
+            DOMAIN="$VAR_DOMAIN"
+          fi
+
+          ZONE="$INPUT_ZONE"
+          if [[ -z "$ZONE" ]]; then
+            ZONE="$VAR_ZONE"
+          fi
+
+          PRICE_CLASS="$INPUT_PRICE_CLASS"
+          if [[ -z "$PRICE_CLASS" ]]; then
+            PRICE_CLASS="$VAR_PRICE_CLASS"
+          fi
+
+          if [[ -n "$DOMAIN" && -z "$ZONE" ]]; then
+            echo "siteHostedZoneId is required when siteDomainName is set" >&2
+            exit 1
+          fi
+
+          echo "role=$ROLE" >> "$GITHUB_OUTPUT"
+          echo "region=$REGION" >> "$GITHUB_OUTPUT"
+          echo "domain=$DOMAIN" >> "$GITHUB_OUTPUT"
+          echo "zone=$ZONE" >> "$GITHUB_OUTPUT"
+          echo "priceClass=$PRICE_CLASS" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ steps.settings.outputs.role }}
+          aws-region: ${{ steps.settings.outputs.region }}
+
+      - name: Install CDK dependencies
+        run: npm ci
+        working-directory: infra/cdk
+
+      - name: Build CDK app
+        run: npm run build
+        working-directory: infra/cdk
+
+      - name: Deploy support site stack
+        shell: bash
+        working-directory: infra/cdk
+        env:
+          SITE_DOMAIN: ${{ steps.settings.outputs.domain }}
+          SITE_ZONE: ${{ steps.settings.outputs.zone }}
+          SITE_PRICE_CLASS: ${{ steps.settings.outputs.priceClass }}
+        run: |
+          set -euo pipefail
+
+          cmd=(npx cdk deploy GarbanzoSiteStack -c deployEc2=false -c deploySite=true --require-approval never)
+
+          if [[ -n "$SITE_DOMAIN" ]]; then
+            cmd+=(-c "siteDomainName=$SITE_DOMAIN")
+            cmd+=(-c "siteHostedZoneId=$SITE_ZONE")
+          fi
+
+          if [[ -n "$SITE_PRICE_CLASS" ]]; then
+            cmd+=(-c "sitePriceClass=$SITE_PRICE_CLASS")
+          fi
+
+          printf 'Running: %q ' "${cmd[@]}"
+          echo
+          "${cmd[@]}"
+
+      - name: Summarize outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          outputs_json="$(aws cloudformation describe-stacks --stack-name GarbanzoSiteStack --query 'Stacks[0].Outputs' --output json)"
+          website_url="$(echo "$outputs_json" | jq -r '.[] | select(.OutputKey=="WebsiteUrl") | .OutputValue // empty')"
+          cloudfront_url="$(echo "$outputs_json" | jq -r '.[] | select(.OutputKey=="CloudFrontUrl") | .OutputValue // empty')"
+
+          {
+            echo "## Support Site Deployment"
+            echo ""
+            if [[ -n "$website_url" ]]; then
+              echo "- Website URL: $website_url"
+            fi
+            if [[ -n "$cloudfront_url" ]]; then
+              echo "- CloudFront URL: $cloudfront_url"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to Garbanzo are documented here.
 - Added an AWS CDK support-site stack (`GarbanzoSiteStack`) to publish `website/` to S3 + CloudFront.
 - Added local Discord demo runtime scaffolding (`DISCORD_DEMO`) with HTTP simulation and parity tests, mirroring the Slack demo pattern.
 - Added custom-domain support to the AWS support-site stack (`siteDomainName` + `siteHostedZoneId`) and wired Patreon support links into site/repo funding metadata.
+- Added GitHub Actions support-site deploy workflow (`deploy-support-site.yml`) for website/CDK site changes.
+- Added sponsorship strategy documentation (`docs/SUPPORT.md`) including Patreon tier guidance aligned with licensing boundaries.
 
 > Note: older changelog sections include internal phase milestones that predate the current tagged release series.
 

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ tests/
 - **Storage:** SQLite via better-sqlite3 (WAL mode, auto-vacuum, nightly backups)
 - **Validation:** Zod
 - **Logging:** Pino (structured JSON)
-- **Testing:** Vitest (467+ tests)
+- **Testing:** Vitest (469+ tests)
 - **PDF:** pdf-lib (D&D character sheets)
 
 ## Development
@@ -598,8 +598,9 @@ Note: Donations (Sponsors/Patreon/Ko-fi) help fund development but do not grant 
 - GitHub Sponsors: https://github.com/sponsors/jjhickman
 - Patreon: https://www.patreon.com/c/garbanzobot
 - (Optional) Configure Ko-fi/custom links in `.env`
-- Public support site: https://d1qesoxr778xh2.cloudfront.net (custom domain migration to `garbanzobot.com` in progress)
+- Public support site: https://garbanzobot.com
 - Optional AWS website deployment via `infra/cdk` (`GarbanzoSiteStack`)
+- Patreon tier strategy + licensing boundaries: `docs/SUPPORT.md`
 
 Owner-side support messaging:
 
@@ -631,6 +632,7 @@ Repo guardrails are configured under `.github/`:
 - `credential-rotation-reminder.yml` opens a monthly credential rotation checklist issue
 - `release-docker.yml` builds and publishes versioned Docker images to GHCR (and optional Docker Hub) on `v*` tags
 - `release-native-binaries.yml` builds and attaches cross-platform native bundles on `v*` tags
+- `deploy-support-site.yml` publishes `GarbanzoSiteStack` (website/CDK site changes) via OIDC role
 - release Docker workflow runs a smoke test against published image health endpoint
 - `FUNDING.yml` enables sponsorship links in GitHub UI
 
@@ -678,6 +680,7 @@ Use `bash scripts/rotate-gh-secrets.sh --help` for full options.
 - [SCALING.md](docs/SCALING.md) — Scaling constraints (Baileys + SQLite) and future path
 - [AWS_MCP.md](docs/AWS_MCP.md) — AWS MCP notes (development/ops tool, not required)
 - [MULTI_PLATFORM.md](docs/MULTI_PLATFORM.md) — Multi-platform roadmap (personas per platform)
+- [SUPPORT.md](docs/SUPPORT.md) — Sponsorship strategy, Patreon tiers, and licensing boundaries
 - [CHANGELOG.md](CHANGELOG.md) — Full release history
 - [CONTRIBUTING.md](CONTRIBUTING.md) — How to contribute
 - [AGENTS.md](AGENTS.md) — Coding agent instructions and conventions

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -105,10 +105,20 @@ cdk deploy GarbanzoSiteStack \
 3. Copy the `WebsiteUrl` output and set it as repo homepage:
 
 ```bash
-gh repo edit --homepage "https://<cloudfront-domain>"
+gh repo edit --homepage "https://<website-url>"
 ```
 
-4. Update your support links:
+4. (Recommended) configure automatic website deploys from GitHub Actions:
+
+- Add `AWS_ROLE_TO_ASSUME` (secret or repo variable) with OIDC trust for this repo
+- Optional repo variables:
+  - `AWS_REGION` (default `us-east-1`)
+  - `SITE_DOMAIN_NAME` (e.g., `garbanzobot.com`)
+  - `SITE_HOSTED_ZONE_ID` (Route53 zone id)
+  - `SITE_PRICE_CLASS` (`100`, `200`, `all`)
+- Workflow: `.github/workflows/deploy-support-site.yml`
+
+5. Update your support links:
 
 - Set `PATREON_URL` in your runtime `.env` (e.g., `https://www.patreon.com/c/garbanzobot`)
 - Keep Patreon handle in `.github/FUNDING.yml` in sync

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -285,6 +285,8 @@ Research and adopt established, free, trustworthy tools for automated security. 
 
 ### Discord-Specific Features
 1. [ ] **Discord bot scaffold** — Discord.js v14, slash commands, guild setup, role-based permissions
+   - [x] Local Discord demo runtime scaffold (`DISCORD_DEMO`) + parity tests
+   - [ ] Official Discord API runtime integration (bot token, guild/channel wiring)
 2. [ ] **WhatsApp ↔ Discord bridge** — relay messages between paired channels (e.g., WA General ↔ Discord #general), media forwarding, sender attribution
 3. [ ] **Discord rich embeds** — leverage Discord's embed system for weather, transit, venue, book results (richer than WhatsApp text)
 4. [ ] **Discord voice channel integration** — announce events, post join links for meetup voice chats

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,56 @@
+# Support Garbanzo
+
+Garbanzo is sustained by community sponsorship and commercial licensing.
+
+## Public Support Links
+
+- GitHub Sponsors: https://github.com/sponsors/jjhickman
+- Patreon: https://www.patreon.com/c/garbanzobot
+- Support website: https://garbanzobot.com
+
+## Patreon Tier Strategy
+
+These tiers are designed to convert community support while staying aligned with the project license model.
+
+1. **Bean Backer** (`$5/month`)
+   - Helps cover hosting and maintenance costs
+   - Access to monthly project update posts
+
+2. **Community Operator** (`$15/month`)
+   - Everything in Bean Backer
+   - Priority voting on roadmap polls and feature focus
+
+3. **Automation Ally** (`$35/month`)
+   - Everything in Community Operator
+   - Quarterly operations write-ups (release workflow, reliability lessons)
+
+4. **Guild Partner** (`$99/month`)
+   - Everything in Automation Ally
+   - One monthly async advisory thread for deployment and architecture questions
+
+5. **Commercial Pathfinder** (`$299/month`)
+   - Everything in Guild Partner
+   - Dedicated commercial-license intake + faster quote turnaround
+   - Includes planning guidance, not a commercial license grant
+
+## Licensing Alignment (Important)
+
+Patreon support does **not** grant commercial rights.
+
+- Commercial usage is governed by `LICENSE` and `COMMERCIAL_LICENSE.md`.
+- Patreon is a support channel and lead-in for organizations that may later need a commercial license.
+
+## Owner Commands for Support Messaging
+
+From owner DM:
+
+- `!support` -> preview support message
+- `!support broadcast` -> broadcast to all enabled groups
+
+Support message content uses:
+
+- `GITHUB_SPONSORS_URL`
+- `PATREON_URL`
+- `KOFI_URL`
+- `SUPPORT_CUSTOM_URL`
+- `SUPPORT_MESSAGE`

--- a/website/index.html
+++ b/website/index.html
@@ -43,6 +43,33 @@
         <ul id="supportLinks"></ul>
       </section>
 
+      <section class="tiers" aria-label="Patreon tiers">
+        <h2>Patreon Tiers</h2>
+        <div class="grid">
+          <article class="card">
+            <h3>Bean Backer <span class="tier-price">$5/mo</span></h3>
+            <p>Monthly project updates and direct support for hosting costs.</p>
+          </article>
+          <article class="card">
+            <h3>Community Operator <span class="tier-price">$15/mo</span></h3>
+            <p>Everything in Bean Backer plus roadmap vote influence.</p>
+          </article>
+          <article class="card">
+            <h3>Automation Ally <span class="tier-price">$35/mo</span></h3>
+            <p>Everything in Community Operator plus quarterly ops deep dives.</p>
+          </article>
+          <article class="card">
+            <h3>Guild Partner <span class="tier-price">$99/mo</span></h3>
+            <p>Everything in Automation Ally plus one monthly async advisory thread.</p>
+          </article>
+          <article class="card">
+            <h3>Commercial Pathfinder <span class="tier-price">$299/mo</span></h3>
+            <p>Priority commercial-license intake and faster quote turnaround.</p>
+          </article>
+        </div>
+        <p class="footnote">Patreon support does not grant commercial rights. Commercial usage requires a separate commercial license.</p>
+      </section>
+
       <footer>
         Built for real communities. Deployed via AWS + Docker. Open source with commercial licensing options.
       </footer>

--- a/website/styles.css
+++ b/website/styles.css
@@ -112,6 +112,21 @@ body {
   background: #fff;
 }
 
+.tiers {
+  margin-top: 24px;
+}
+
+.tier-price {
+  color: var(--accent);
+  font-size: 0.9em;
+}
+
+.footnote {
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
 .support ul {
   margin: 10px 0 0;
   padding-left: 18px;


### PR DESCRIPTION
## Objective

Automate support-site deployments in GitHub Actions and formalize Patreon strategy docs/tier messaging aligned with licensing constraints.

Closes:

## Problem

- Website updates required manual CDK deploys from a workstation.
- Patreon support links existed, but tier strategy and licensing boundaries were not documented in one place.
- Phase 8 planning docs needed clearer sequencing for identity + bridge safety before WA↔Discord relay.

## Solution

- Add workflow automation:
  - `.github/workflows/deploy-support-site.yml`
  - deploys `GarbanzoSiteStack` on `website/**` and site-CDK stack changes
  - supports custom domain context via repo vars / workflow inputs
- Add support strategy doc:
  - `docs/SUPPORT.md` with Patreon tier recommendations and explicit license boundary language
- Update public-facing docs and website:
  - `README.md` support links/site URL/docs references/test count
  - `docs/AWS.md` workflow setup guidance for OIDC role and site vars
  - `website/index.html` + `website/styles.css` tier presentation content
  - `CHANGELOG.md` Unreleased notes
- Update future roadmap/design ordering:
  - `docs/ROADMAP.md` marks local Discord demo scaffold done under Phase 8 item
  - `docs/MULTI_PLATFORM.md` adds unified identity + bridge safety prerequisites

## User-Facing Impact

- Website and Patreon messaging are clearer and more conversion-friendly.
- Maintainers can automate support-site deploys in CI instead of manual-only workflows.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A; docs/workflow/site copy)
- [x] Manual smoke test completed (describe below)

Manual smoke test notes:

- Deployed latest site updates to `https://garbanzobot.com` via CDK.
- Verified custom domain serves updated content and Patreon config.
- Ran owner support broadcast (`!support broadcast`) from production auth context.

## Risk and Rollback

- Risk level: low-to-medium
- Primary risk: deploy workflow requires correctly configured OIDC role/vars
- Rollback approach: disable workflow and continue manual `cdk deploy` path

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (workflow input validation)
- [x] Health/monitoring implications reviewed (none for bot runtime)
- [x] Performance/cost implications reviewed (CloudFront/site updates)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated
- [x] Release note/customer-facing summary prepared (`CHANGELOG.md` Unreleased)

## Reviewer Focus Areas

1. `deploy-support-site.yml` assumptions around role/vars and deploy command assembly
2. Patreon tier wording in `docs/SUPPORT.md` and website copy (appeal vs licensing clarity)
3. Phase 8 sequencing updates (`ROADMAP` + `MULTI_PLATFORM`) for safe bridge rollout