### PR TITLE
chore: genericize setup and workflow defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,8 @@ NEWSAPI_KEY=
 # Web search (Brave Search API)
 BRAVE_SEARCH_API_KEY=
 
-# ── Support / Patronage (optional) ───────────
+# ── Optional owner links/messages ────────────
+# These values are used only by owner-side messaging commands.
 GITHUB_SPONSORS_URL=
 PATREON_URL=
 KOFI_URL=
@@ -58,7 +59,7 @@ SUPPORT_MESSAGE=
 
 # Optional feedback -> GitHub issue automation (owner-approved)
 GITHUB_ISSUES_TOKEN=
-GITHUB_ISSUES_REPO=jjhickman/garbanzo-bot
+GITHUB_ISSUES_REPO=owner/repo
 
 # ── Infrastructure ───────────────────────────
 # Ollama endpoint (local inference on Terra)

--- a/.github/workflows/deploy-support-site.yml
+++ b/.github/workflows/deploy-support-site.yml
@@ -1,4 +1,4 @@
-name: Deploy Support Site
+name: Deploy Website
 
 on:
   push:
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       siteDomainName:
-        description: 'Optional custom domain (example: garbanzobot.com)'
+        description: 'Optional custom domain (example: example.com)'
         required: false
       siteHostedZoneId:
         description: 'Optional Route53 hosted zone ID (required with custom domain)'
@@ -27,12 +27,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-support-site
+  group: deploy-website
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy GarbanzoSiteStack
+    name: Deploy website stack
     runs-on: ubuntu-latest
 
     steps:
@@ -114,7 +114,7 @@ jobs:
         run: npm run build
         working-directory: infra/cdk
 
-      - name: Deploy support site stack
+      - name: Deploy website stack
         shell: bash
         working-directory: infra/cdk
         env:
@@ -148,7 +148,7 @@ jobs:
           cloudfront_url="$(echo "$outputs_json" | jq -r '.[] | select(.OutputKey=="CloudFrontUrl") | .OutputValue // empty')"
 
           {
-            echo "## Support Site Deployment"
+            echo "## Website Deployment"
             echo ""
             if [[ -n "$website_url" ]]; then
               echo "- Website URL: $website_url"

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -195,7 +195,7 @@ async function main() {
     output.write('  npm run setup -- --non-interactive --providers=gemini --gemini-key=$GEMINI_API_KEY --gemini-model=gemini-1.5-flash --gemini-pricing-input-per-m=0.15 --gemini-pricing-output-per-m=0.60\n');
     output.write('  npm run setup -- --non-interactive --profile=events --features=weather,transit,events,venues,poll --group-id=120...@g.us --group-name="Events"\n');
     output.write('  npm run setup -- --non-interactive --persona-file=./my-persona.md --owner-jid=your_number@s.whatsapp.net\n');
-    output.write('  npm run setup -- --non-interactive --app-version=0.2.0 --github-issues-repo=jjhickman/garbanzo-bot --github-issues-token=$GITHUB_ISSUES_TOKEN\n');
+    output.write('  npm run setup -- --non-interactive --app-version=0.2.0 --github-issues-repo=owner/repo --github-issues-token=$GITHUB_ISSUES_TOKEN\n');
     output.write('  npm run setup -- --non-interactive --dry-run --providers=openai --profile=lightweight\n');
     process.exit(0);
   }
@@ -429,8 +429,8 @@ async function main() {
       ? (cli.options['github-issues-token'] ?? existing.GITHUB_ISSUES_TOKEN ?? '')
       : await rl.question(`GITHUB_ISSUES_TOKEN [${existing.GITHUB_ISSUES_TOKEN ?? ''}]: `);
     const githubIssuesRepo = nonInteractive
-      ? (cli.options['github-issues-repo'] ?? existing.GITHUB_ISSUES_REPO ?? 'jjhickman/garbanzo-bot')
-      : await rl.question(`GITHUB_ISSUES_REPO [${existing.GITHUB_ISSUES_REPO ?? 'jjhickman/garbanzo-bot'}]: `);
+      ? (cli.options['github-issues-repo'] ?? existing.GITHUB_ISSUES_REPO ?? 'owner/repo')
+      : await rl.question(`GITHUB_ISSUES_REPO [${existing.GITHUB_ISSUES_REPO ?? 'owner/repo'}]: `);
 
     const profileKeys = Object.keys(FEATURE_PROFILES);
     const profileLabels = profileKeys.map((key) => `${FEATURE_PROFILES[key].label} — ${FEATURE_PROFILES[key].description}`);
@@ -527,7 +527,7 @@ async function main() {
       SUPPORT_CUSTOM_URL: (supportCustomUrl || existing.SUPPORT_CUSTOM_URL || '').trim(),
       SUPPORT_MESSAGE: (supportMessage || existing.SUPPORT_MESSAGE || '').trim(),
       GITHUB_ISSUES_TOKEN: (githubIssuesToken || existing.GITHUB_ISSUES_TOKEN || '').trim(),
-      GITHUB_ISSUES_REPO: (githubIssuesRepo || existing.GITHUB_ISSUES_REPO || 'jjhickman/garbanzo-bot').trim(),
+      GITHUB_ISSUES_REPO: (githubIssuesRepo || existing.GITHUB_ISSUES_REPO || 'owner/repo').trim(),
       OLLAMA_BASE_URL: (ollamaBaseUrl || existing.OLLAMA_BASE_URL || 'http://127.0.0.1:11434').trim(),
       LOG_LEVEL: (existing.LOG_LEVEL || 'info').trim(),
       APP_VERSION: (appVersion || existing.APP_VERSION || DEFAULT_APP_VERSION).trim(),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -41,7 +41,7 @@ const envSchema = z.object({
   NEWSAPI_KEY: z.string().optional(),
   BRAVE_SEARCH_API_KEY: z.string().optional(),
 
-  // Optional support / patronage links
+  // Optional external links for owner messaging
   GITHUB_SPONSORS_URL: z.string().url().optional(),
   PATREON_URL: z.string().url().optional(),
   KOFI_URL: z.string().url().optional(),
@@ -50,7 +50,7 @@ const envSchema = z.object({
 
   // Optional GitHub issue automation for owner-approved feedback
   GITHUB_ISSUES_TOKEN: z.string().optional(),
-  GITHUB_ISSUES_REPO: z.string().default('jjhickman/garbanzo-bot'),
+  GITHUB_ISSUES_REPO: z.string().default('owner/repo'),
 
   // Infrastructure
   HEALTH_PORT: z.coerce.number().int().min(1).max(65535).default(3001),


### PR DESCRIPTION
## Objective

Do a non-markdown tidy pass to remove personal/repo-specific defaults from setup and workflow entry points while keeping features intact.

Closes:

## Problem

- Setup and config defaults still used a repository-specific `owner/repo` value tied to one account.
- Website deploy workflow labels/descriptions still used support/business-specific wording and an example custom domain tied to this project.

## Solution

- Genericize setup/config defaults:
  - `.env.example` uses `GITHUB_ISSUES_REPO=owner/repo`
  - `scripts/setup.mjs` non-interactive examples/prompts/defaults now use `owner/repo`
  - `src/utils/config.ts` default for `GITHUB_ISSUES_REPO` set to `owner/repo`
- Neutralize workflow wording:
  - `.github/workflows/deploy-support-site.yml`
  - workflow name/step text changed from "Support Site" to generic "Website"
  - custom-domain input example changed to `example.com`

## User-Facing Impact

- Forks/adopters no longer inherit account-specific defaults for issue automation.
- Website deployment workflow reads as generic project infrastructure rather than business-specific support tooling.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (default-string/workflow wording updates only)

## Risk and Rollback

- Risk level: low
- Primary risk: none; behavior unchanged except defaults/text
- Rollback approach: revert this PR

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed) (N/A)
- [x] Relevant `docs/*.md` updated (N/A)
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. Confirm no account-specific defaults remain in setup/config for `GITHUB_ISSUES_REPO`
2. Confirm workflow rename/wording remains functionally equivalent