### PR TITLE
docs: remove readme current status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@
 
 A WhatsApp community bot built with [Baileys](https://github.com/WhiskeySockets/Baileys) and multi-provider AI routing (Claude, OpenAI, Gemini, plus local Ollama). Originally built for a 120+ member Boston-area meetup group, designed to be adaptable to any community or locale.
 
-## Current Status
-
-- Production runtime: WhatsApp (Slack local demo mode available for pipeline testing)
-- Latest tagged release: `v0.1.6`
-- Delivery state: Phases 1-7 complete, Phase 8 (platform expansion) queued
-
 ## Why Garbanzo
 
 - Turn busy group chats into actionable community coordination (events, plans, recs, summaries)


### PR DESCRIPTION
## Objective

Remove the README "Current Status" section so the project front page stays evergreen and avoids operational state framing.

Closes:

## Problem

- README included a time-sensitive "Current Status" block (runtime/release/phase state) that you requested to remove.

## Solution

- Delete the `## Current Status` section and its bullets from `README.md`.

## User-Facing Impact

- README is cleaner and less stateful while preserving feature and architecture guidance.

## Verification

- [x] `npm run check`
- [x] Feature-specific tests added/updated as needed (N/A)
- [ ] Manual smoke test completed (describe below)

Manual smoke test notes:

- N/A (docs-only)

## Risk and Rollback

- Risk level: low
- Primary risk: none
- Rollback approach: restore removed section in README

## Operational and Security Checklist

- [x] No secrets or credentials added to tracked files
- [x] Error handling/log context added for new failure paths (N/A)
- [x] Health/monitoring implications reviewed (none)
- [x] Performance/cost implications reviewed (none)
- [x] Open Dependabot PRs reviewed (not applicable)

## Docs and Communication

- [x] `README.md` updated (if behavior changed)
- [x] Relevant `docs/*.md` updated (N/A)
- [ ] Release note/customer-facing summary prepared (if applicable)

## Reviewer Focus Areas

1. Ensure only the Current Status section was removed
2. Ensure README flow remains coherent after deletion