### PR TITLE
chore: prepare Apache-2.0 licensing for v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to Garbanzo are documented here.
 
 ## [Unreleased]
 
-- No unreleased changes yet.
+### Changed
+
+- Switched project licensing to Apache License 2.0 and updated package metadata accordingly.
+- Reworked licensing docs to reflect Apache-2.0 commercial-use permissions and optional paid support/services.
+- Updated README, website footer, and Docker Hub overview copy to remove source-available/commercial-trial wording.
 
 ## [0.1.7] — 2026-02-16
 

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -1,31 +1,32 @@
-# Commercial License
+# Commercial Use and Services
 
-Garbanzo is available under the Prosperity Public License 3.0.0 for noncommercial use and a limited commercial trial.
+Garbanzo is licensed under Apache License 2.0.
 
-If you want to use Garbanzo for commercial purposes beyond the trial period, you need a separate commercial license from the contributor.
+That means commercial use is allowed without purchasing a separate commercial software license.
 
-## What counts as commercial?
+## What this means in practice
 
-Commercial purposes include using Garbanzo:
+- You can use Garbanzo inside a for-profit company.
+- You can build products and services with Garbanzo.
+- You can offer paid setup, hosting, and integrations using Garbanzo.
 
-- inside a for-profit company (internal use counts)
-- as part of a paid product or service
-- to provide consulting, managed hosting, or integrations for clients
-- in any context primarily intended for commercial advantage or private monetary compensation
+You are still responsible for complying with Apache-2.0 terms, especially preserving license and notice requirements when redistributing modified versions.
 
-## How to get a commercial license
+## Paid services (optional)
+
+If you want help beyond community support, contact for:
+
+- onboarding and deployment assistance
+- implementation and integration help
+- priority troubleshooting and advisory support
 
 Contact:
 
 - Email: jjhickman@pm.me
-- GitHub: https://github.com/jjhickman/garbanzo-bot (open an issue with subject "Commercial license")
+- GitHub: https://github.com/jjhickman/garbanzo-bot
 
-Include:
+## Trademarks and branding
 
-- your company name
-- how you plan to use Garbanzo (which platform, expected users/tenants)
-- whether you need priority support / SLA
+Apache-2.0 covers code rights. Brand names and logos are handled separately.
 
-## Patents and trademarks
-
-A commercial license may include additional terms for support, warranties, or branding. The Garbanzo name and logos may be subject to trademark-style restrictions even when the code is licensed.
+See `TRADEMARK.md` for current branding guidance.

--- a/LICENSE
+++ b/LICENSE
@@ -1,57 +1,201 @@
-The Prosperity Public License 3.0.0
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Contributor: Josh Hickman
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Source Code: https://github.com/jjhickman/garbanzo-bot
+1. Definitions.
 
-Purpose
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
 
-This license allows you to use and share this software for noncommercial purposes for free and to try this software for commercial purposes for thirty days.
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
 
-Agreement
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
 
-In order to receive this license, you have to agree to its rules. Those rules are both obligations under that agreement and conditions to your license. Don't do anything with this software that triggers a rule you can't or won't follow.
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
 
-Notices
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
 
-Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
 
-Commercial Trial
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
 
-Limit your use of this software for commercial purposes to a thirty-day trial period. If you use this software for work, your company gets one trial period for all personnel, not one trial per person.
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
 
-Contributions Back
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
 
-Developing feedback, changes, or additions that you contribute back to the contributor on the terms of a standardized public software license such as the Blue Oak Model License 1.0.0, the Apache License 2.0, the MIT license, or the two-clause BSD license doesn't count as use for a commercial purpose.
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
 
-Personal Uses
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
 
-Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, doesn't count as use for a commercial purpose.
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
 
-Noncommercial Organizations
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
 
-Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution doesn't count as use for a commercial purpose regardless of the source of funding or obligations resulting from the funding.
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
 
-Defense
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
 
-Don't make any legal claim against anyone accusing this software, with or without changes, alone or with other technology, of infringing any patent.
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
 
-Copyright
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
 
-The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
 
-Patent
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
 
-The contributor licenses you to do everything with this software that would otherwise infringe any patents they can license or become able to license.
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
 
-Reliability
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
 
-The contributor can't revoke this license.
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
 
-Excuse
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
 
-You're excused for unknowingly breaking Notices if you take all practical steps to comply within thirty days of learning you broke the rule.
+END OF TERMS AND CONDITIONS
 
-No Liability
+APPENDIX: How to apply the Apache License to your work.
 
-As far as the law allows, this software comes as is, without any warranty or condition, and the contributor won't be liable to anyone for any damages related to this software or this license, under any kind of legal claim.
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!) The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2026 Josh Hickman
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE_FAQ.md
+++ b/LICENSE_FAQ.md
@@ -1,43 +1,39 @@
 # License FAQ
 
-Garbanzo is licensed under the Prosperity Public License 3.0.0.
-
-This is a source-available license that:
-
-- allows free use for noncommercial purposes
-- allows a limited commercial trial period (30 days per company)
-- requires a commercial license for ongoing commercial use
+Garbanzo is licensed under Apache License 2.0.
 
 This FAQ is a plain-English guide and is not legal advice. The license text in `LICENSE` controls.
 
-## Can I use Garbanzo for personal projects?
+## Can I use Garbanzo commercially?
 
-Yes. Personal use for hobby projects, private entertainment, research, and learning is noncommercial under the license.
-
-## Can I use Garbanzo for a community group or nonprofit?
-
-Yes. The license explicitly permits use by charitable organizations, educational institutions, public research, public safety/health, environmental protection, and government institutions.
-
-## Can my company use Garbanzo internally?
-
-A short trial is permitted.
-
-Ongoing use inside a for-profit company is commercial use and requires a commercial license.
-
-## Can I offer Garbanzo as a hosted service for clients?
-
-No, not without a commercial license.
+Yes. Apache-2.0 allows commercial use.
 
 ## Can I modify Garbanzo?
 
-Yes. You can modify and share changes under the same license terms. If you contribute changes back under a standard public software license (MIT/Apache/Blue Oak/BSD-2), that contribution activity does not count as commercial use.
+Yes. Apache-2.0 allows modification and redistribution.
 
-## What about contractors/consultants?
+## Do I need to open-source my changes?
 
-If you are paid to set up or run Garbanzo for someone else, that is commercial use.
+No. Apache-2.0 does not require you to publish your source.
 
-## Why this license?
+If you redistribute binaries or source, you must preserve required notices and include the Apache-2.0 license text.
 
-The goal is to keep Garbanzo accessible to individuals and community organizers while preventing free-riding commercial usage.
+## Can I offer Garbanzo as a hosted service?
 
-If you're building a business on top of Garbanzo, please contact for licensing.
+Yes. Apache-2.0 allows hosted and managed use.
+
+## What about patents?
+
+Apache-2.0 includes a patent grant from contributors, with termination conditions described in the license.
+
+## Are Garbanzo name and logos covered by Apache-2.0?
+
+No. Trademark and branding rights are separate.
+
+See `TRADEMARK.md`.
+
+## Is paid support still available?
+
+Yes. Paid support and implementation help are optional services, not separate software license permissions.
+
+See `COMMERCIAL_LICENSE.md`.

--- a/README.md
+++ b/README.md
@@ -615,9 +615,11 @@ sudo apt-get install -y iptables-persistent
 sudo netfilter-persistent save
 ```
 
-## Commercial Licensing
+## Commercial Use and Support
 
-Garbanzo is source-available for noncommercial use. For commercial usage terms and licensing options, see `COMMERCIAL_LICENSE.md`.
+Garbanzo is licensed under Apache-2.0, so commercial use is allowed.
+
+If you want paid onboarding, implementation help, or priority support, see `COMMERCIAL_LICENSE.md`.
 
 ## Main Branch Stability
 
@@ -651,10 +653,10 @@ Repo guardrails are configured under `.github/`:
 
 ## License
 
-Garbanzo is source-available under the [Prosperity Public License 3.0.0](LICENSE):
+Garbanzo is licensed under [Apache License 2.0](LICENSE).
 
-- Free for noncommercial use (personal + qualifying noncommercial organizations)
-- Commercial use is allowed for a limited 30-day trial
-- Ongoing commercial use requires a commercial license (see `COMMERCIAL_LICENSE.md`)
+- Commercial use is allowed
+- Modification and redistribution are allowed under Apache-2.0 terms
+- Trademark and branding rights are covered separately (see `TRADEMARK.md`)
 
-See `LICENSE_FAQ.md` for examples.
+See `LICENSE_FAQ.md` for a quick guide.

--- a/docs/DOCKERHUB_OVERVIEW.md
+++ b/docs/DOCKERHUB_OVERVIEW.md
@@ -23,8 +23,8 @@ cp .env.example .env
 3) Run a pinned release:
 
 ```bash
-APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
-APP_VERSION=0.1.6 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+APP_VERSION=0.1.7 docker compose -f docker-compose.yml -f docker-compose.prod.yml pull garbanzo
+APP_VERSION=0.1.7 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 
 Health check:
@@ -48,9 +48,9 @@ This repository publishes both GHCR and Docker Hub tags from the same release wo
 - `latest`
   - Most recent stable release
   - Only published for non-prerelease versions
-- `0.1.6`
+- `0.1.7`
   - Semver tag without the leading `v`
-- `v0.1.6`
+- `v0.1.7`
   - Git tag style (kept for convenience)
 
 All tags are multi-arch where available:
@@ -66,7 +66,7 @@ All tags are multi-arch where available:
 
 ## License
 
-Garbanzo is source-available under the Prosperity Public License 3.0.0 (see `LICENSE` in the source repository). Noncommercial use is free; commercial use beyond the trial period requires a commercial license.
+Garbanzo is licensed under Apache License 2.0 (see `LICENSE` in the source repository).
 
 Source code and docs: https://github.com/jjhickman/garbanzo-bot
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "garbanzo",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbanzo",
-      "version": "0.1.7",
-      "license": "SEE LICENSE IN LICENSE",
+      "version": "0.1.8",
+      "license": "Apache-2.0",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@whiskeysockets/baileys": "^6.7.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbanzo",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Garbanzo Bean — multi-platform chat operations bot for communities and small teams",
   "type": "module",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
     "node": ">=20.0.0"
   },
   "author": "Josh Hickman",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache-2.0",
   "dependencies": {
     "@hapi/boom": "^10.0.1",
     "@whiskeysockets/baileys": "^6.7.16",

--- a/website/index.html
+++ b/website/index.html
@@ -85,7 +85,7 @@
       </section>
 
       <footer>
-        Built for communities and small teams. Docker-first deployment. Source-available with commercial licensing options.
+        Built for communities and small teams. Docker-first deployment. Apache-2.0 licensed.
       </footer>
     </main>
 


### PR DESCRIPTION
## Why
Shift Garbanzo licensing to Apache-2.0 to match the updated roadmap and remove source-available/commercial-trial constraints from public positioning.

## What changed
- replace `LICENSE` with Apache License 2.0 text
- set package metadata to `Apache-2.0` and bump version to `0.1.8`
- rework `COMMERCIAL_LICENSE.md` and `LICENSE_FAQ.md` to reflect Apache-2.0 + optional paid services
- update README, website footer, and Docker Hub overview language to remove old commercial-trial wording
- add changelog entry under Unreleased for the licensing transition

## Verification
- npm run check

## Notes
- Repo About metadata was updated to include Apache-2.0 context.
- Docker Hub overview sync will pick up doc changes on next tagged Docker release.