### PR TITLE
fix: remove personal email from public-facing files and add PII guard

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -78,6 +78,22 @@ title = "Garbanzo Bot secret scanning config"
       '''tests/''',
     ]
 
+# ─── PII: Personal Email Guard ─────────────────────────────────────────
+# Block any personal/private email addresses from being committed.
+# Contact info must use project-level channels (GitHub Issues, etc.),
+# never personal inboxes. Covers common private email providers.
+
+[[rules]]
+  id = "pii-personal-email"
+  description = "Personal email address — use GitHub Issues or project contact channel"
+  regex = '''[a-zA-Z0-9._%+\-]+@(pm\.me|proton\.me|protonmail\.com|tutanota\.com|tutamail\.com|tuta\.io|duck\.com|icloud\.com|me\.com|fastmail\.com|mailbox\.org|posteo\.de|disroot\.org|riseup\.net)'''
+  tags = ["pii", "email"]
+  [rules.allowlist]
+    description = "Allow references in gitleaks config and git history tooling"
+    paths = [
+      '''\.gitleaks\.toml''',
+    ]
+
 # ─── Entropy-based generic secret detection ────────────────────────────
 # The built-in generic-api-key rule handles most cases. We tighten the
 # entropy threshold to reduce false positives on base64 constants.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,15 +257,19 @@ npm run test:watch
 - Commit messages: `type: short description` (e.g., `feat: add weather command`, `fix: handle empty message body`)
 - Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 - Branch from `main` for features
-- Run `npm run check` before committing
+- **Before every commit:** Run `npm run check` (audit:secrets → audit:deps → typecheck → lint → test). Fix any failures before committing.
+- **Before every push / PR:** Run `npm run gh:dependabot` to check for open Dependabot PRs. The CI automation guard will block PRs if Dependabot PRs are pending. Either merge them first or add the `allow-open-dependabot` label with justification.
+- **After every push:** Monitor the GitHub Actions Quality Gate check. If it fails, fix the issue and push again — do not leave a PR with failing checks.
 
 ## Three-Tier Boundaries
 
 ### ✅ Always Do
-- Run `npm run check` before committing (runs secrets audit → typecheck → lint → test)
+- Run `npm run check` before committing (runs secrets audit → audit:deps → typecheck → lint → test). **Fix all failures before committing.**
 - Run `npm run setup:hooks` after cloning to install the pre-commit PII/secret scanner
+- Run `npm run gh:dependabot` before pushing or opening a PR — resolve or label open Dependabot PRs
 - Run `npm run typecheck` after editing TypeScript files
 - Run `npm run audit:secrets` after adding any config values, API keys, or identifiers
+- Monitor CI checks after every push — fix failures immediately, never leave a PR red
 - Research existing tools/libraries/APIs before implementing any new feature or utility
 - Validate all environment variables with Zod at startup
 - Log errors with structured context (Pino)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,17 +45,26 @@ Before implementing any feature, task, or utility, **research whether a reliable
 
 All code changes are scanned for hardcoded secrets before they can be committed or pushed. This is enforced at three levels:
 
-1. **Pre-commit hook** — `gitleaks protect --staged` runs automatically on every `git commit`. Blocks commits containing API keys, tokens, private keys, or other secrets.
+1. **Pre-commit hook** — `gitleaks git --staged` runs automatically on every `git commit`. Blocks commits containing API keys, tokens, private keys, personal emails, or other secrets/PII. Install hooks with `npm run setup:hooks`.
 2. **`npm run check`** — The full pre-commit check pipeline (`audit:secrets` → `typecheck` → `lint` → `test`) includes a gitleaks scan of the working directory. Run this before every commit.
 3. **`npm run audit:secrets`** — Standalone secret scan. Use `--verbose` for detailed findings, `--staged` for only staged files.
 
-**Configuration:** `.gitleaks.toml` at project root. Built-in rules detect 150+ secret types. Custom rules added for WhatsApp JIDs. Allowlists configured for files that legitimately reference patterns (docs, examples, config).
+**Configuration:** `.gitleaks.toml` at project root. Built-in rules detect 150+ secret types. Custom rules added for WhatsApp JIDs and personal email addresses. Allowlists configured for files that legitimately reference patterns (docs, examples, config).
 
 **If gitleaks flags a finding:**
 - Move the secret to `.env` (gitignored)
 - Reference via `process.env.VAR_NAME` in code
 - For test files, use fake values (`test_key_xxx`, `5550001234`)
 - For genuine false positives, add an inline `gitleaks:allow` comment or update `.gitleaks.toml` allowlist
+
+### PII Guard: No Personal Contact Information in Code
+
+**Never commit personal email addresses, phone numbers, or private contact details to the repository.** This rule is enforced by both the `pii-personal-email` gitleaks rule and the pre-commit hook.
+
+- **Public contact channels only** — Use GitHub Issues, Discussions, or project-level email addresses for any contact links in websites, docs, or config files. Never use personal inboxes.
+- **The gitleaks `pii-personal-email` rule** blocks commits containing emails from private providers (ProtonMail, Tutanota, iCloud, Fastmail, etc.). See `.gitleaks.toml` for the full list.
+- **If you need to reference a maintainer** — link to their GitHub profile, not their personal email.
+- **AI agents must never** output, embed, or commit personal identifying information (names, emails, phone numbers, addresses) into any file unless the owner explicitly instructs them to do so in that specific conversation.
 
 ## Commands
 
@@ -80,6 +89,9 @@ npm run test
 
 # Scan for hardcoded secrets
 npm run audit:secrets
+
+# Install git hooks (pre-commit PII/secret scanning)
+npm run setup:hooks
 
 # Build for production
 npm run build
@@ -251,6 +263,7 @@ npm run test:watch
 
 ### ✅ Always Do
 - Run `npm run check` before committing (runs secrets audit → typecheck → lint → test)
+- Run `npm run setup:hooks` after cloning to install the pre-commit PII/secret scanner
 - Run `npm run typecheck` after editing TypeScript files
 - Run `npm run audit:secrets` after adding any config values, API keys, or identifiers
 - Research existing tools/libraries/APIs before implementing any new feature or utility
@@ -272,6 +285,8 @@ npm run test:watch
 
 ### 🚫 Never Do
 - Hardcode API keys, tokens, or phone numbers in source code
+- Commit personal email addresses, phone numbers, or private contact info — use project-level channels (GitHub Issues)
+- Output, embed, or commit PII (names, emails, addresses) unless the owner explicitly requests it in the current conversation
 - Auto-send messages without the bot being explicitly @mentioned (except moderation alerts to owner DM)
 - Commit `.env`, `baileys_auth/`, or `data/*.db` files
 - Delete or modify Baileys auth state files while the bot is running

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -13,7 +13,7 @@
 
 If you want to use Garbanzo branding in a commercial product or offering, contact the contributor:
 
-- Email: jjhickman@pm.me
+- Open a [GitHub Issue](https://github.com/jjhickman/garbanzo-bot/issues)
 
 ## Note
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3484,24 +3484,37 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3793,9 +3806,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5214,9 +5227,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gh:switch:owner": "bash scripts/gh-workflow.sh switch-owner",
     "gh:switch:author": "bash scripts/gh-workflow.sh switch-author",
     "rotate:gh-secrets": "bash scripts/rotate-gh-secrets.sh",
+    "setup:hooks": "bash scripts/install-hooks.sh",
     "db:postgres:init": "node scripts/postgres-init.mjs",
     "db:sqlite:migrate:postgres": "node scripts/sqlite-to-postgres.mjs",
     "db:sqlite:verify:postgres": "node scripts/postgres-verify.mjs",

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Install git hooks for the garbanzo-bot project.
+# Run once after cloning: npm run setup:hooks
+set -euo pipefail
+
+HOOKS_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
+
+# Pre-commit: secret + PII scanning via gitleaks
+cat > "$HOOKS_DIR/pre-commit" << 'HOOK'
+#!/usr/bin/env bash
+# Pre-commit hook: block secrets and PII from being committed.
+# Runs gitleaks on staged files only for fast feedback.
+
+set -euo pipefail
+
+if ! command -v gitleaks &>/dev/null; then
+  echo "⚠  gitleaks not installed — skipping secret scan"
+  echo "   Install: https://github.com/gitleaks/gitleaks#installing"
+  exit 0
+fi
+
+echo "🔍 Scanning staged changes for secrets and PII..."
+gitleaks git --staged --config .gitleaks.toml --verbose
+
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+  echo ""
+  echo "❌ Commit blocked: gitleaks found secrets or PII in staged files."
+  echo "   Fix the findings above, then try again."
+  echo "   If this is a false positive, add an allowlist entry in .gitleaks.toml"
+  exit 1
+fi
+
+echo "✅ No secrets or PII found in staged changes."
+HOOK
+
+chmod +x "$HOOKS_DIR/pre-commit"
+echo "✅ Git hooks installed successfully."

--- a/website/index.html
+++ b/website/index.html
@@ -107,7 +107,7 @@
           Garbanzo Bean is operated as an independent software project focused on reliable AI chat operations for communities.
         </p>
         <ul class="trust-links">
-          <li>Contact: <a id="contactEmailLink" href="mailto:jjhickman@pm.me">jjhickman@pm.me</a></li>
+          <li>Contact: <a id="contactEmailLink" href="https://github.com/jjhickman/garbanzo-bot/issues">Open a GitHub Issue</a></li>
           <li><a id="privacyPolicyLink" href="./privacy.html">Privacy Policy</a></li>
           <li><a id="termsLink" href="./terms.html">Terms of Service</a></li>
         </ul>
@@ -200,11 +200,11 @@
           setLink('ctaDemo', cfg.demoUrl || 'https://demo.garbanzobot.com', cfg.demoLabel || 'Try Live Demo');
           setLink('ctaSecondary', cfg.ctaSecondaryUrl || cfg.patreonUrl || cfg.githubSponsorsUrl, cfg.ctaSecondaryLabel || 'Support the AI roadmap');
 
-          if (cfg.contactEmail) {
+          if (cfg.contactUrl) {
             const contact = document.getElementById('contactEmailLink');
             if (contact) {
-              contact.href = `mailto:${cfg.contactEmail}`;
-              contact.textContent = cfg.contactEmail;
+              contact.href = cfg.contactUrl;
+              contact.textContent = 'Open a GitHub Issue';
             }
           }
 

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -82,8 +82,8 @@
 
         <h2>9. Contact</h2>
         <p>
-          Privacy questions can be sent to
-          <a href="mailto:jjhickman@pm.me">jjhickman@pm.me</a>.
+          Privacy questions can be submitted via
+          <a href="https://github.com/jjhickman/garbanzo-bot/issues">GitHub Issues</a>.
         </p>
       </section>
     </main>

--- a/website/site-config.json
+++ b/website/site-config.json
@@ -13,7 +13,7 @@
   "ctaSecondaryLabel": "Support the AI Roadmap",
   "ctaSecondaryUrl": "https://www.patreon.com/c/garbanzobot",
   "supportBlurb": "Support helps fund provider integrations, AI workflow improvements, and reliable release operations.",
-  "contactEmail": "jjhickman@pm.me",
+  "contactUrl": "https://github.com/jjhickman/garbanzo-bot/issues",
   "privacyPolicyUrl": "./privacy.html",
   "termsUrl": "./terms.html",
   "supportTiers": [

--- a/website/terms.html
+++ b/website/terms.html
@@ -79,8 +79,8 @@
 
         <h2>10. Contact</h2>
         <p>
-          Questions about these Terms can be sent to
-          <a href="mailto:jjhickman@pm.me">jjhickman@pm.me</a>.
+          Questions about these Terms can be submitted via
+          <a href="https://github.com/jjhickman/garbanzo-bot/issues">GitHub Issues</a>.
         </p>
       </section>
     </main>


### PR DESCRIPTION
## Summary

**URGENT HOTFIX** — Personal email was exposed in public website pages, causing spam. This PR:

- **Removes personal email** from all 5 files where it appeared (website index, terms, privacy pages, site-config.json, TRADEMARK.md)
- **Replaces with GitHub Issues links** as the public contact channel
- **Adds `pii-personal-email` gitleaks rule** that blocks commits containing emails from private providers (ProtonMail, Tutanota, iCloud, Fastmail, etc.)
- **Adds pre-commit hook** (`scripts/install-hooks.sh`) that runs gitleaks on staged files before every commit
- **Updates AGENTS.md** with PII Guard policy section and Never Do rules to prevent AI agents from committing PII

## Files Changed

| File | Change |
|------|--------|
| `website/index.html` | Removed email, updated JS config loader to use `contactUrl` |
| `website/terms.html` | Replaced email with GitHub Issues link |
| `website/privacy.html` | Replaced email with GitHub Issues link |
| `website/site-config.json` | `contactEmail` → `contactUrl` (GitHub Issues) |
| `TRADEMARK.md` | Replaced email with GitHub Issues link |
| `.gitleaks.toml` | Added `pii-personal-email` rule (13 private email providers) |
| `scripts/install-hooks.sh` | New pre-commit hook installer |
| `package.json` | Added `setup:hooks` npm script |
| `AGENTS.md` | Added PII Guard section + updated boundaries |

## Testing

- [x] `rg '@pm.me'` returns zero results across codebase
- [x] Pre-commit hook executed and passed on this commit
- [x] gitleaks scan clean

## Post-Merge

All websites (garbanzobot.com, demo site) need immediate redeployment to remove cached pages with the exposed email.